### PR TITLE
Make observer aware of accordionOpen state

### DIFF
--- a/packages/accordion/src/accordion.tsx
+++ b/packages/accordion/src/accordion.tsx
@@ -45,7 +45,7 @@ export const Accordion = React.forwardRef<HTMLDivElement, AccordionProps>((props
     disabled,
   });
 
-  const [declaredObserver, setDeclaredObserver] = React.useState<{ disconnect: Function }>();
+  const [declaredObserver, setDeclaredObserver] = React.useState<MutationObserver>();
   const [accordionOpen, setAccordionOpen] = React.useState(initalOpen ?? false);
   const contentEl = useRef<HTMLDivElement>(null);
 


### PR DESCRIPTION
Tidigare beräknades ny höjd för accordionkomponenten vid (nästan) alla ändringar i child-komponenter, utan att ta hänsyn till om accordionOpen var true eller ej.

Med denna ändring så beräknas ny höjd enbart om accordionOpen === true, genom att accordionOpen läggs till i useEffectens dependencylista.

Som en följd av detta behöver man se till att när useEffecten körs igen så ska tidigare skapade mutation observers disconnectas.