### PR TITLE
Updated modal behavior

### DIFF
--- a/packages/modal/src/confirm/confirm.tsx
+++ b/packages/modal/src/confirm/confirm.tsx
@@ -1,10 +1,10 @@
+import ErrorSharpIcon from '@mui/icons-material/ErrorSharp';
+import HelpOutlineSharpIcon from '@mui/icons-material/HelpOutlineSharp';
+import InfoSharpIcon from '@mui/icons-material/InfoSharp';
 import { Button } from '@sk-web-gui/button';
 import { __DEV__ } from '@sk-web-gui/utils';
 import * as React from 'react';
 import { Dialog } from '../dialog';
-import ErrorSharpIcon from '@mui/icons-material/ErrorSharp';
-import HelpOutlineSharpIcon from '@mui/icons-material/HelpOutlineSharp';
-import InfoSharpIcon from '@mui/icons-material/InfoSharp';
 
 type UseDialogShowReturnType = {
   show: boolean;
@@ -75,7 +75,7 @@ export const ConfirmationDialogContextProvider: React.FC<ConfirmationDialogConte
       dismissLabel: dismissLabel || 'Nej',
       dialogType: dialogType,
       icon: icon,
-      labelAs: labelAs || 'h4',
+      labelAs: labelAs || 'h1',
     });
     setShow(true);
     return new Promise(function (resolve) {
@@ -118,6 +118,7 @@ export const ConfirmationDialogContextProvider: React.FC<ConfirmationDialogConte
 
       {content && (
         <Dialog
+          aria-label={`${content.title} ${content.message}`}
           show={show}
           label={
             <span className="flex items-center justify-center gap-2">
@@ -125,6 +126,7 @@ export const ConfirmationDialogContextProvider: React.FC<ConfirmationDialogConte
             </span>
           }
           labelAs={content.labelAs}
+          onClose={handleDismiss}
           className={content.dialogType ? `border-2 border-${content.dialogType}` : ``}
         >
           <Dialog.Content>

--- a/packages/modal/src/modal/modal.tsx
+++ b/packages/modal/src/modal/modal.tsx
@@ -15,6 +15,7 @@ export interface IModalProps extends DefaultProps {
   as?: React.ElementType;
   labelAs?: React.ElementType;
   hideLabel?: boolean;
+  'aria-label'?: string;
 }
 
 export const Modal = React.forwardRef<HTMLDivElement, IModalProps>((props, ref) => {
@@ -27,10 +28,12 @@ export const Modal = React.forwardRef<HTMLDivElement, IModalProps>((props, ref) 
     children,
     disableCloseOutside = false,
     as: Content = 'article',
-    labelAs = 'h4',
+    labelAs = 'h1',
     hideLabel = false,
     ...rest
   } = props;
+
+  const modalRef = React.useRef<any>();
 
   const onCloseHandler = () => {
     if (onClose) {
@@ -38,20 +41,23 @@ export const Modal = React.forwardRef<HTMLDivElement, IModalProps>((props, ref) 
     }
   };
 
-  const onCloseOutsideHandler = () => {
-    if (onClose && !disableCloseOutside) {
-      onClose();
+  React.useEffect(() => {
+    if (show && props['aria-label']) {
+      setTimeout(() => {
+        modalRef.current && modalRef.current.removeAttribute('aria-labelledby');
+      });
     }
-  };
+  }, [show, props['aria-label']]);
 
   return (
     <div className="Modal">
       <Transition appear show={show} as={Fragment}>
         <Dialog
+          ref={modalRef}
           open={show}
           as="div"
           className="fixed inset-0 z-20 overflow-y-auto bg-opacity-50 bg-gray-500"
-          onClose={onCloseOutsideHandler}
+          onClose={onCloseHandler}
           {...rest}
         >
           <div className="min-h-screen px-4 text-center">
@@ -64,7 +70,10 @@ export const Modal = React.forwardRef<HTMLDivElement, IModalProps>((props, ref) 
               leaveFrom="opacity-100"
               leaveTo="opacity-0"
             >
-              <Dialog.Overlay className="fixed inset-0" />
+              <Dialog.Overlay
+                className="fixed inset-0"
+                style={{ pointerEvents: disableCloseOutside ? 'none' : undefined }}
+              />
             </Transition.Child>
 
             {/* This element is to trick the browser into centering the modal contents. */}


### PR DESCRIPTION
H1 as standard label
aria-labels overrides aria-labelledby
Can close with "esc" when click outside is disabled