### PR TITLE
Select list upwards

### DIFF
--- a/packages/core/src/components/forms.js
+++ b/packages/core/src/components/forms.js
@@ -332,7 +332,7 @@ module.exports = Forms = (colors) => ({
     '&-list': {
       '@apply z-10 absolute overflow-y-auto w-full bg-white mt-0 border border-gray-stroke border-t-0 border-b': {
       },
-      '&.showabovebox': {
+      '&.showabove': {
         '@apply border-t border-b-0': {}
       }
     },

--- a/packages/core/src/components/forms.js
+++ b/packages/core/src/components/forms.js
@@ -309,6 +309,16 @@ module.exports = Forms = (colors) => ({
     },
   },
 
+  '.form-select-list-transition': {
+    '@apply absolute z-50 w-full bg-white shadow-lg max-h-60 rounded-md py-1 text-base ring-1 ring-black ring-opacity-5 overflow-auto focus:outline-none sm:text-sm': {},
+    '&.showabove': {
+      '@apply mb-1 bottom-full': {}
+    },
+    '&:not(.showabove)': {
+      '@apply mt-1 top-full': {}
+    }
+  },
+
   '.form-select': {
     '@apply justify-between items-center grow text-body bg-white caret-transparent select-none cursor-pointer border-gray-stroke':
       {},
@@ -320,7 +330,11 @@ module.exports = Forms = (colors) => ({
       '@apply grow-0': {},
     },
     '&-list': {
-      '@apply z-10 absolute overflow-y-auto w-full bg-white mt-0 border border-gray-stroke border-t-0': {},
+      '@apply z-10 absolute overflow-y-auto w-full bg-white mt-0 border border-gray-stroke border-t-0 border-b': {
+      },
+      '&.showabovebox': {
+        '@apply border-t border-b-0': {}
+      }
     },
     '&-has-multiple-choices': {
       '@apply flex w-full h-full justify-between items-center pr-md': {},

--- a/packages/forms/src/select/index.tsx
+++ b/packages/forms/src/select/index.tsx
@@ -184,13 +184,17 @@ const InternalSelect = React.forwardRef<HTMLInputElement, InternalSelectProps>((
               leave="transition ease-in duration-100"
               leaveFrom="opacity-100"
               leaveTo="opacity-0"
-              className={cx('form-select-list-transition', upwards ? 'showabove' : null)}
             >
               <Listbox.Options
                 id="listitems"
                 static
                 style={{ maxHeight: `${defaultOptionsAmount * 5 + 1}rem` }}
-                className={cx('form-select-list', listClassName, upwards ? 'showabovebox' : null)}
+                className={cx(
+                  'form-select-list',
+                  'form-select-list-transition',
+                  listClassName,
+                  upwards ? 'showabove' : null
+                )}
               >
                 {children &&
                   (children as any).map((option: any, index: number) => {

--- a/packages/forms/stories/select.stories.tsx
+++ b/packages/forms/stories/select.stories.tsx
@@ -1,11 +1,12 @@
+import { Meta } from '@storybook/react';
 import React, { useState } from 'react';
 import { Select, SelectProps } from '../src';
 
 export default {
-  title: 'Komponenter/Dropdown/Komponent',
+  title: 'Komponenter/Dropdown/Select',
   component: Select,
   tags: ['autodocs'],
-};
+} as Meta;
 
 const people = [
   { id: 1, name: 'Durward Reynolds', unavailable: false },
@@ -63,6 +64,16 @@ export const Template = (args: SelectProps) => {
 };
 
 Template.storyName = 'Select';
+
+export const Ovanför = () => (
+  <>
+    <div className="h-[100px]"></div>
+    <Select onChange={() => ({})} placeholder="Välj hob">
+      <Select.Option value={{ label: 'Sam', data: {} }} />
+      <Select.Option value={{ label: 'Frodo', data: {} }} />
+    </Select>
+  </>
+);
 
 export const Inaktiverad = () => (
   <Select onChange={() => ({})} disabled placeholder="Outline">


### PR DESCRIPTION
En "fulfix" för select-komponenten: rita ut dropdownlistan uppåt när följande uppfylls:

1. Listan beräknas sträcka sig utanför fönstret nedåt
2. Listan skulle rymmas ovanför istället

MutationObserver används för att detektera när dropdownen öppnas, och height, top, etc för elementen används för att beräkna position  av över- och nederkant relativt fönstret.

Fulfixen är att använda <Transition/> med className vilket lintern inte gillar.