### PR TITLE
fix: enables button to fire click on Enter

### DIFF
--- a/packages/popup-menu/src/popup-menu-item.tsx
+++ b/packages/popup-menu/src/popup-menu-item.tsx
@@ -42,10 +42,8 @@ export const PopupMenuItem: React.FC<PopupMenuItemProps> = (props) => {
         prev && prev();
         break;
       case 'Enter':
-        if (target?.nodeName !== 'BUTTON') {
-          target?.dispatchEvent(clickEvent);
-          !preventClose && close && close();
-        }
+        target?.dispatchEvent(clickEvent);
+        !preventClose && close && close();
         break;
       case ' ':
         if (target?.nodeName !== 'INPUT') {


### PR DESCRIPTION
- removed proposedly unnecessary if-check

Make sure on next council meeting that it does not wreck havoc before merging.