### PR TITLE
Feature/lucide icon

### DIFF
--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -42,7 +42,8 @@
     "@sk-web-gui/icon": "2.0.1",
     "@sk-web-gui/label": "1.0.4",
     "@sk-web-gui/theme": "2.3.1",
-    "@sk-web-gui/utils": "2.0.1"
+    "@sk-web-gui/utils": "2.0.1",
+    "lucide-react": "^0.372.0"
   },
   "peerDependencies": {
     "react": ">=18.2.0"

--- a/packages/accordion/src/disclosure/disclosure.tsx
+++ b/packages/accordion/src/disclosure/disclosure.tsx
@@ -7,6 +7,7 @@ import { Label } from '@sk-web-gui/label';
 import { Divider } from '@sk-web-gui/divider';
 import { useDisclosureClass } from './styles';
 import { Icon, IconProps } from '@sk-web-gui/icon';
+import { Minus, Plus } from 'lucide-react';
 
 export interface DisclosureProps extends DefaultProps, React.ComponentPropsWithRef<'div'> {
   /**
@@ -44,7 +45,7 @@ export interface DisclosureProps extends DefaultProps, React.ComponentPropsWithR
    */
   variant?: 'default' | 'alt';
   /** Leading icon. Will be displayed before the header */
-  icon?: React.ComponentProps<IconProps>['name'];
+  icon?: React.ReactNode;
   /** Support text. Will be displayed after the header. */
   supportText?: string;
   /** Label. Will be displayed after the header. */
@@ -90,7 +91,7 @@ export const Disclosure = React.forwardRef<HTMLDivElement, DisclosureProps>((pro
   const _open = context.open;
   const Comp = headerAs || context.headerAs || 'label';
   const inverted = _inverted ?? context.inverted;
-  const labelInverted = _labelInverted ?? inverted ? false : true;
+  const labelInverted = (_labelInverted ?? inverted) ? false : true;
   const [disclosureOpen, setDisclosureOpen] = React.useState(open || initalOpen);
   const id = _id || `sk-disclosure-${useId()}`;
 
@@ -149,7 +150,7 @@ export const Disclosure = React.forwardRef<HTMLDivElement, DisclosureProps>((pro
         onClick={onClick}
       >
         <div className="sk-disclosure-toggle">
-          {icon && <Icon name={icon} />}
+          {icon}
           <div className="sk-disclosure-title-wrapper">
             <Comp className="sk-disclosure-title" id={`${id}-label`}>
               {header}
@@ -173,7 +174,7 @@ export const Disclosure = React.forwardRef<HTMLDivElement, DisclosureProps>((pro
             aria-expanded={disclosureOpen}
             aria-labelledby={`${id}-label`}
           >
-            {disclosureOpen ? <Icon name="minus" /> : <Icon name="plus" />}
+            {<Icon icon={disclosureOpen ? <Minus /> : <Plus />} />}
           </Button>
         </div>
       </div>

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -57,7 +57,8 @@
     "sanitize-html": "^2.13.0",
     "universal-cookie": "^6.1.1",
     "usehooks-ts": "^3.1.0",
-    "zustand": "^4.5.2"
+    "zustand": "^4.5.2",
+    "lucide-react": "^0.372.0"
   },
   "peerDependencies": {
     "react": ">=18.2.0"

--- a/packages/ai/src/components/ai-corner-module/ai-corner-module-header-menu-item.tsx
+++ b/packages/ai/src/components/ai-corner-module/ai-corner-module-header-menu-item.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 interface AICornerModuleHeaderMenuItemProps extends Omit<React.ComponentPropsWithoutRef<'li'>, 'onClick' | 'children'> {
   onClick?: React.ComponentPropsWithoutRef<'button'>['onClick'];
   buttonProps?: React.ComponentProps<ButtonProps>;
-  icon: React.ComponentProps<IconProps>['name'];
+  icon: React.ComponentProps<IconProps>['icon'];
   label: string;
 }
 
@@ -76,7 +76,7 @@ export const AICornerModuleHeaderMenuItem = React.forwardRef<HTMLLIElement, AICo
           tabIndex={tabIndex}
           {...buttonProps}
         >
-          <Icon name={icon} />
+          <Icon icon={icon} />
         </Button>
         {showTooltip && (
           <Tooltip ref={tooltipRef} position={tooltipPosition} data-rightoutside={tooltipRightOutside}>

--- a/packages/ai/src/components/ai-corner-module/ai-corner-module-header-menu.tsx
+++ b/packages/ai/src/components/ai-corner-module/ai-corner-module-header-menu.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { AICornerModuleDefaultProps } from './ai-corner-module';
 import { AICornerModuleHeaderProps } from './ai-corner-module-header';
 import { AICornerModuleHeaderMenuItem } from './ai-corner-module-header-menu-item';
+import { Pencil, ArrowDownRight, ArrowUpLeft, History, ChevronsDown, ChevronsUp } from 'lucide-react';
 
 export interface AICornerModuleHeaderMenuProps
   extends Omit<AICornerModuleDefaultProps, 'title' | 'subtitle'>,
@@ -143,7 +144,7 @@ export const AICornerModuleHeaderMenu = React.forwardRef<HTMLUListElement, AICor
           <>
             {!docked && !fullscreen && (
               <AICornerModuleHeaderMenuItem
-                icon="pencil"
+                icon={<Pencil />}
                 tabIndex={0}
                 onKeyDown={handleKeyboardNavigation}
                 label="Ny fråga"
@@ -153,7 +154,7 @@ export const AICornerModuleHeaderMenu = React.forwardRef<HTMLUListElement, AICor
             )}
             {!disableFullscreen && !docked && !isMobile && (
               <AICornerModuleHeaderMenuItem
-                icon={fullscreen ? 'arrow-down-right' : 'arrow-up-left'}
+                icon={fullscreen ? <ArrowDownRight /> : <ArrowUpLeft />}
                 tabIndex={!isMobile && fullscreen ? 0 : -1}
                 onKeyDown={handleKeyboardNavigation}
                 label={`${fullscreen ? 'Stäng' : 'Öppna'} fullskärmsläge`}
@@ -163,7 +164,7 @@ export const AICornerModuleHeaderMenu = React.forwardRef<HTMLUListElement, AICor
             )}
             {!docked && isMobile && showSessionHistory && (
               <AICornerModuleHeaderMenuItem
-                icon="history"
+                icon={<History />}
                 tabIndex={-1}
                 onKeyDown={handleKeyboardNavigation}
                 label="Tidigare frågor"
@@ -177,7 +178,7 @@ export const AICornerModuleHeaderMenu = React.forwardRef<HTMLUListElement, AICor
               />
             )}
             <AICornerModuleHeaderMenuItem
-              icon={docked ? 'chevrons-up' : 'chevrons-down'}
+              icon={docked ? <ChevronsUp /> : <ChevronsDown />}
               tabIndex={docked ? 0 : -1}
               onKeyDown={handleKeyboardNavigation}
               label={docked ? 'Öppna assistent' : 'Minimera'}

--- a/packages/ai/src/components/ai-corner-module/ai-corner-module-header.tsx
+++ b/packages/ai/src/components/ai-corner-module/ai-corner-module-header.tsx
@@ -8,6 +8,7 @@ import { AICornerModuleDefaultProps } from './ai-corner-module';
 import { AICornerModuleHeaderMenu } from './ai-corner-module-header-menu';
 import { AssistantSwitch, AssistantSwitchProps } from '../assistant-switch';
 import { AssistantAvatar } from '../assistant-avatar';
+import { Plus, MessageCircle } from 'lucide-react';
 
 export interface AICornerModuleHeaderProps extends AICornerModuleDefaultProps, React.ComponentPropsWithoutRef<'div'> {
   variant?: 'default' | 'alt';
@@ -64,13 +65,13 @@ export const AICornerModuleHeader = React.forwardRef<HTMLDivElement, AICornerMod
           <Button
             size="sm"
             color="vattjom"
-            rightIcon={<Icon name="plus" />}
+            rightIcon={<Icon icon={<Plus />} />}
             onClick={() => onNewSession && onNewSession()}
           >
             Ny fråga
           </Button>
           <div className="sk-ai-corner-module-header-title">
-            <Icon name="message-circle" />
+            <Icon icon={<MessageCircle />} />
             <span className="sk-ai-corner-module-header-heading-name">
               {session?.name ? session?.name : 'Ny fråga'}
             </span>

--- a/packages/ai/src/components/ai-corner-module/ai-corner-module-mobile-menu.tsx
+++ b/packages/ai/src/components/ai-corner-module/ai-corner-module-mobile-menu.tsx
@@ -7,7 +7,7 @@ import { AssistantInfo, SessionHistory } from '../../types';
 import { AICornerModuleProps } from './ai-corner-module';
 import { AICornerModuleHeader } from './ai-corner-module-header';
 import { AICornerModuleSessions } from './ai-corner-module-sessions';
-
+import { X } from 'lucide-react';
 interface AICornerModuleMobileMenuProps extends Omit<React.ComponentPropsWithoutRef<'div'>, 'children'> {
   show: boolean;
   assistant: AssistantInfo;
@@ -95,7 +95,7 @@ export const AICornerModuleMobileMenu = React.forwardRef<HTMLDivElement, AICorne
             id="sk-ai-corner-module-mobile-menu-close-button"
             onClick={() => onClose && onClose()}
           >
-            <Icon name="x" />
+            <Icon icon={<X />} />
           </Button>
         </div>
         <div className="sk-ai-corner-module-mobile-menu-content">

--- a/packages/ai/src/components/ai-corner-module/ai-corner-module-session-history.tsx
+++ b/packages/ai/src/components/ai-corner-module/ai-corner-module-session-history.tsx
@@ -4,7 +4,7 @@ import { Icon } from '@sk-web-gui/icon';
 import { cx } from '@sk-web-gui/utils';
 import React from 'react';
 import { SessionHistory } from '../../types';
-
+import { MessageCircle } from 'lucide-react';
 export interface AICornerModuleSessionHistoryProps extends React.ComponentPropsWithoutRef<'div'> {
   sessions: SessionHistory;
   title: string;
@@ -56,7 +56,7 @@ export const AICornerModuleSessionHistory = React.forwardRef<HTMLDivElement, AIC
                 role="menuitem"
                 id={`sk-ai-session-item-${session.id}`}
                 onClick={() => onSelectSession && onSelectSession(session.id)}
-                leftIcon={<Icon name="message-circle" />}
+                leftIcon={<Icon icon={<MessageCircle />} />}
                 onKeyDown={(e) => handleKeyboardNavigation(e, idPrefix + session.id)}
               >
                 {session.name}

--- a/packages/ai/src/components/bubble.tsx
+++ b/packages/ai/src/components/bubble.tsx
@@ -1,6 +1,7 @@
 import { Icon } from '@sk-web-gui/icon';
 import { cx } from '@sk-web-gui/utils';
 import React from 'react';
+import { ArrowRight } from 'lucide-react';
 
 export interface BubbleProps extends React.ComponentPropsWithoutRef<'button'> {
   /**
@@ -15,7 +16,7 @@ export const Bubble = React.forwardRef<HTMLButtonElement, BubbleProps>((props, r
   return (
     <button ref={ref} className={cx('sk-ai-bubble', className)} data-color={color} {...rest}>
       {children}
-      <Icon name="arrow-right" size={18} />
+      <Icon icon={<ArrowRight />} size={18} />
       <span className="sk-ai-bubble-tail" />
     </button>
   );

--- a/packages/ai/src/components/feedback.tsx
+++ b/packages/ai/src/components/feedback.tsx
@@ -3,6 +3,7 @@ import { Icon } from '@sk-web-gui/icon';
 import React, { useRef, useState } from 'react';
 import { giveFeedback } from '../services';
 import { useSessions } from '../session-store';
+import { X, ThumbsUp, ThumbsDown } from 'lucide-react';
 
 export interface FeedbackProps extends React.ComponentPropsWithoutRef<'div'> {
   sessionId: string;
@@ -70,7 +71,7 @@ export const Feedback = React.forwardRef<HTMLDivElement, FeedbackProps>((props, 
         }
       }}
     >
-      <Icon name="x" size={28} />
+      <Icon icon={<X />} size={28} />
     </Button>
   );
 
@@ -89,7 +90,7 @@ export const Feedback = React.forwardRef<HTMLDivElement, FeedbackProps>((props, 
           className="sk-ai-feedback-button"
           onClick={() => handleFeedback(1)}
         >
-          <Icon name="thumbs-up" />
+          <Icon icon={<ThumbsUp />} />
         </Button>
         <Button
           ref={thumbDownButtonRef}
@@ -106,7 +107,7 @@ export const Feedback = React.forwardRef<HTMLDivElement, FeedbackProps>((props, 
           className="sk-ai-feedback-button"
           onClick={() => handleFeedback(-1)}
         >
-          <Icon name="thumbs-down" />
+          <Icon icon={<ThumbsDown />} />
         </Button>
       </div>
       {showFeedbackReason || feedbackLoading || showThanks ? (

--- a/packages/ai/src/components/input-section/input-section-button.tsx
+++ b/packages/ai/src/components/input-section/input-section-button.tsx
@@ -3,6 +3,7 @@ import { Icon } from '@sk-web-gui/icon';
 import { cx } from '@sk-web-gui/utils';
 import React from 'react';
 import { InputSectionDefaultProps } from './input-section';
+import { SendHorizontal } from 'lucide-react';
 
 interface InputSectionButtonProps
   extends React.ComponentPropsWithoutRef<typeof Button.Component>,
@@ -18,7 +19,7 @@ export const InputSectionButton = React.forwardRef<HTMLButtonElement, InputSecti
       size={isMobile || variant === 'inset' ? 'sm' : 'md'}
       iconButton={isMobile}
       variant="primary"
-      children={isMobile ? <Icon name="send-horizontal" /> : 'Skicka'}
+      children={isMobile ? <Icon icon={<SendHorizontal />} /> : 'Skicka'}
       aria-label={isMobile ? 'Skicka' : undefined}
       type="submit"
       {...rest}

--- a/packages/ai/src/components/new-session-button.tsx
+++ b/packages/ai/src/components/new-session-button.tsx
@@ -2,6 +2,7 @@ import { Button } from '@sk-web-gui/button';
 import { Icon } from '@sk-web-gui/icon';
 import { cx } from '@sk-web-gui/utils';
 import React from 'react';
+import { Plus } from 'lucide-react';
 
 export interface NewSessionButtonProps extends React.ComponentPropsWithoutRef<typeof Button> {
   helperText?: string;
@@ -24,7 +25,7 @@ export const NewSessionButton = React.forwardRef<HTMLButtonElement, NewSessionBu
   const helperText =
     _helperText ?? '💡 För att få relevanta svar på frågor som rör andra ämnen behöver du starta en ny konversation.';
 
-  const icon = _icon ?? <Icon name="plus" />;
+  const icon = _icon ?? <Icon icon={<Plus />} />;
 
   return (
     <div className={cx('sk-ai-newsession', wrapperClassName)}>

--- a/packages/button/stories/button-group.stories.tsx
+++ b/packages/button/stories/button-group.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
 import { Button, ButtonProps } from '../src';
-import { Icon } from '@sk-web-gui/icon';
+import Icon from '@sk-web-gui/icon';
 
 export default {
   title: 'Komponenter/Button/Button.Group',

--- a/packages/button/stories/button.stories.tsx
+++ b/packages/button/stories/button.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/react';
 import { Button, ButtonProps } from '../src';
-import { Icon } from '@sk-web-gui/icon';
+import Icon from '@sk-web-gui/icon';
 
 export default {
   title: 'Komponenter/Button',

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -39,7 +39,8 @@
   "dependencies": {
     "@sk-web-gui/button": "2.0.9",
     "@sk-web-gui/link": "1.1.3",
-    "@sk-web-gui/utils": "2.0.1"
+    "@sk-web-gui/utils": "2.0.1",
+    "lucide-react": "^0.372.0"
   },
   "peerDependencies": {
     "react": ">=18.2.0"

--- a/packages/card/src/card.tsx
+++ b/packages/card/src/card.tsx
@@ -3,6 +3,7 @@ import { Icon } from '@sk-web-gui/icon';
 import { Link } from '@sk-web-gui/link';
 import { __DEV__, cx, DefaultProps, getValidChildren } from '@sk-web-gui/utils';
 import React from 'react';
+import { ArrowRight, Calendar, Clock4 } from 'lucide-react';
 
 import { cloneElement } from 'react';
 
@@ -150,7 +151,7 @@ export const CardBody = React.forwardRef<HTMLDivElement, CardBodyProps>((props, 
         inverted={inverted == 'true' ? false : true}
         className="sk-card-body-icon"
       >
-        <Icon name="arrow-right" size={20} />
+        <Icon icon={<ArrowRight />} size={20} />
       </Button>
     </div>
   );
@@ -189,13 +190,13 @@ export const CardMeta = React.forwardRef<HTMLDivElement, CardMetaProps>((props, 
       {datetime ? (
         <>
           <span>
-            <Icon name="calendar" variant="ghost" size={20} />
+            <Icon icon={<Calendar />} variant="ghost" size={20} />
             <time dateTime={datetime?.toISOString().split('T')[0]}>
               {datetime?.getDay()} {monthNames[datetime?.getMonth()]} {datetime?.getFullYear()}
             </time>
           </span>
           <span>
-            <Icon name="clock-4" variant="ghost" size={20} />
+            <Icon icon={<Clock4 />} variant="ghost" size={20} />
             <time dateTime={datetime?.getHours() + ':' + datetime?.getMinutes()}>
               {datetime?.getHours()}:{('0' + datetime?.getMinutes()).slice(-2)}
             </time>

--- a/packages/card/src/meta-card.tsx
+++ b/packages/card/src/meta-card.tsx
@@ -2,6 +2,7 @@ import { Link } from '@sk-web-gui/link';
 import { Icon } from '@sk-web-gui/icon';
 import { DefaultProps, __DEV__, cx } from '@sk-web-gui/utils';
 import React from 'react';
+import { Text, ExternalLink } from 'lucide-react';
 
 // NOTE: Meta Card component
 
@@ -36,13 +37,13 @@ export const MetaCard = React.forwardRef<HTMLDivElement, MetaCardProps>((props, 
           {...rest}
           ref={ref}
         >
-          <Icon className={cx('sk-meta-card-text-icon', className)} size={36} name="text"></Icon>
+          <Icon className={cx('sk-meta-card-text-icon', className)} size={36} icon={<Text />}></Icon>
           <div className={cx('sk-meta-card-body', className)}>{children}</div>
-          <Icon className={cx('sk-meta-card-external-link-icon', className)} size={32} name="external-link"></Icon>
+          <Icon className={cx('sk-meta-card-external-link-icon', className)} size={32} icon={<ExternalLink />}></Icon>
         </Link>
       ) : (
         <div className={cx('sk-meta-card', className)} data-color={color ? color : undefined} {...rest} ref={ref}>
-          <Icon className={cx('sk-meta-card-text-icon', className)} size={36} name="text"></Icon>
+          <Icon className={cx('sk-meta-card-text-icon', className)} size={36} icon={<Text />}></Icon>
           <div className={cx('sk-meta-card-body', className)}>{children}</div>
           <div className={cx('sk-meta-card-external-link-icon', className)}></div>
         </div>

--- a/packages/chip/package.json
+++ b/packages/chip/package.json
@@ -38,7 +38,8 @@
   },
   "dependencies": {
     "@sk-web-gui/icon": "2.0.1",
-    "@sk-web-gui/utils": "2.0.1"
+    "@sk-web-gui/utils": "2.0.1",
+    "lucide-react": "^0.372.0"
   },
   "peerDependencies": {
     "react": ">=18.2.0"

--- a/packages/chip/src/chip.tsx
+++ b/packages/chip/src/chip.tsx
@@ -1,6 +1,7 @@
 import { cx } from '@sk-web-gui/utils';
 import { Icon } from '@sk-web-gui/icon';
 import React from 'react';
+import { X } from 'lucide-react';
 
 export interface ChipProps extends React.ComponentPropsWithRef<'button'> {
   strong?: boolean;
@@ -20,7 +21,7 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>((props, ref) 
       {...rest}
     >
       {children}
-      <Icon name="x" />
+      <Icon icon={<X />} />
     </button>
   );
 });

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -41,7 +41,8 @@
     "@sk-web-gui/icon": "2.0.1",
     "@sk-web-gui/theme": "2.3.1",
     "@sk-web-gui/utils": "2.0.1",
-    "usehooks-ts": "^3.1.0"
+    "usehooks-ts": "^3.1.0",
+    "lucide-react": "^0.372.0"
   },
   "peerDependencies": {
     "react": ">=18.2.0"

--- a/packages/forms/src/checkbox/checkbox.tsx
+++ b/packages/forms/src/checkbox/checkbox.tsx
@@ -3,6 +3,7 @@ import { cx, useForkRef, __DEV__, DefaultProps } from '@sk-web-gui/utils';
 import React from 'react';
 import { useEffect, useRef } from 'react';
 import { Icon } from '@sk-web-gui/icon';
+import { Minus, Check } from 'lucide-react';
 
 import { useCheckboxClass, useCheckboxLabelClass } from './styles';
 import { useCheckboxGroup } from './checkbox-group';
@@ -136,7 +137,7 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxItemProps>((p
         className={cx(checkboxClasses)}
         {...rest}
       />
-      <Icon.Padded variant="ghost" name={indeterminate ? 'minus' : 'check'} />
+      <Icon.Padded variant="ghost" icon={indeterminate ? <Minus /> : <Check />} />
       {children && labelPosition === 'right' && <span className={cx(checkboxLabelClasses)}>{children}</span>}
     </label>
   );

--- a/packages/forms/src/combobox/combobox-option.tsx
+++ b/packages/forms/src/combobox/combobox-option.tsx
@@ -2,6 +2,7 @@ import { Icon } from '@sk-web-gui/icon';
 import { DefaultProps, cx, useForkRef } from '@sk-web-gui/utils';
 import React from 'react';
 import { useCombobox } from './combobox-context';
+import { Check } from 'lucide-react';
 
 export interface ComboboxOptionProps extends DefaultProps, Omit<React.ComponentPropsWithRef<'input'>, 'onClick'> {
   value: string;
@@ -101,7 +102,7 @@ export const ComboboxOption = React.forwardRef<HTMLInputElement, ComboboxOptionP
         context.activeId === id ? 'active' : ''
       )}
     >
-      <Icon name="check" aria-hidden data-checked={checked} className="sk-form-combobox-list-option-tick" />
+      <Icon icon={<Check />} aria-hidden data-checked={checked} className="sk-form-combobox-list-option-tick" />
       {children}
       <input
         tabIndex={-1}

--- a/packages/forms/src/switch/switchcomponent.tsx
+++ b/packages/forms/src/switch/switchcomponent.tsx
@@ -2,7 +2,7 @@ import { useFormControl } from '../form-control';
 import { Icon } from '@sk-web-gui/icon';
 import { __DEV__, cx } from '@sk-web-gui/utils';
 import React from 'react';
-
+import { Check } from 'lucide-react';
 export interface SwitchProps extends Omit<React.ComponentPropsWithRef<'input'>, 'size'> {
   /** Set the switch color
    * @default tertiary
@@ -59,7 +59,7 @@ export const Switch = React.forwardRef<HTMLInputElement, SwitchProps>((props, re
       <div className={'sk-form-switch'} data-disabled={disabled} data-color={color ? color : undefined}>
         <div className={'sk-form-switch-box'}>
           <Icon.Padded
-            name="check"
+            icon={<Check />}
             color={color}
             variant={disabled ? 'ghost' : 'tertiary'}
             rounded

--- a/packages/forms/stories/input.stories.tsx
+++ b/packages/forms/stories/input.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Input, InputProps } from '../src';
 import { Meta } from '@storybook/react';
-import { Icon } from '@sk-web-gui/icon';
+import Icon from '@sk-web-gui/icon';
 
 export default {
   title: 'Komponenter/Formulär',

--- a/packages/forms/stories/text-field.stories.tsx
+++ b/packages/forms/stories/text-field.stories.tsx
@@ -2,7 +2,7 @@ import { Meta } from '@storybook/react';
 import React from 'react';
 import { Input } from '../src';
 import { TextField, TextFieldProps } from '../src/text-field/text-field';
-import { Icon } from '@sk-web-gui/icon';
+import Icon from '@sk-web-gui/icon';
 
 export default {
   title: 'Komponenter/TextField',

--- a/packages/icon/src/icon.tsx
+++ b/packages/icon/src/icon.tsx
@@ -1,12 +1,7 @@
 import { __DEV__, cx, DefaultProps } from '@sk-web-gui/utils';
-import { icons } from 'lucide-react';
 import React from 'react';
-import dynamicIconImports from 'lucide-react/dynamicIconImports';
-
-type IconNames = keyof typeof dynamicIconImports;
 
 export interface IconProps extends DefaultProps, React.ComponentPropsWithRef<'span'> {
-  name?: IconNames;
   /** @default primary */
   color?:
     | 'tertiary'
@@ -30,17 +25,8 @@ export interface IconProps extends DefaultProps, React.ComponentPropsWithRef<'sp
   size?: number | string | 'fit';
 }
 
-function toPascalCase(text: string) {
-  return text.replace(/(^\w|-\w)/g, clearAndUpper);
-}
-
-function clearAndUpper(text: string) {
-  return text.replace(/-/, '').toUpperCase();
-}
-
 export const Icon = React.forwardRef<HTMLSpanElement, IconProps>((props, ref) => {
   const {
-    name,
     color = 'primary',
     icon,
     rounded = false,
@@ -50,7 +36,7 @@ export const Icon = React.forwardRef<HTMLSpanElement, IconProps>((props, ref) =>
     className,
     ...rest
   } = props;
-  const LucideIcon = name ? icons[toPascalCase(name) as keyof typeof icons] : undefined;
+
   return (
     <span
       ref={ref}
@@ -62,10 +48,9 @@ export const Icon = React.forwardRef<HTMLSpanElement, IconProps>((props, ref) =>
       data-rounded={rounded ? rounded : undefined}
       data-inverted={inverted ? inverted : undefined}
       data-size={size ? size : undefined}
-      data-testid={name ? `sk-icon-${name}` : undefined}
       {...rest}
     >
-      {icon ? icon : LucideIcon ? <LucideIcon /> : undefined}
+      {icon}
     </span>
   );
 });

--- a/packages/icon/src/index.ts
+++ b/packages/icon/src/index.ts
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Icon as InternalIcon, IconProps as InternalIconProps } from './icon';
+import { LucideIcon as InternalLucideIcon, LucideIconProps as InternalLucideIconProps } from './lucide-icon';
 import { IconPadded } from './icon-padded';
+import LucideIconPadded from './lucide-icon-padded';
 
 interface IconProps extends React.ForwardRefExoticComponent<InternalIconProps> {
   Component: typeof InternalIcon;
@@ -13,5 +15,16 @@ export const Icon = {
   Padded: IconPadded,
 } as IconProps;
 
-export type { IconProps };
-export default Icon;
+interface LucideIconProps extends React.ForwardRefExoticComponent<InternalLucideIconProps> {
+  Component: typeof InternalLucideIcon;
+  Padded: typeof LucideIconPadded;
+}
+
+export const LucideIcon = {
+  ...InternalLucideIcon,
+  Component: InternalLucideIcon,
+  Padded: LucideIconPadded,
+} as LucideIconProps;
+
+export type { IconProps, LucideIconProps };
+export default LucideIcon;

--- a/packages/icon/src/lucide-icon-padded.tsx
+++ b/packages/icon/src/lucide-icon-padded.tsx
@@ -1,0 +1,15 @@
+import { __DEV__, cx } from '@sk-web-gui/utils';
+import React from 'react';
+import LucideIcon, { type LucideIconProps } from './lucide-icon';
+
+export const LucideIconPadded = React.forwardRef<HTMLSpanElement, LucideIconProps>((props, ref) => {
+  const { className, ...rest } = props;
+
+  return <LucideIcon ref={ref} className={cx('sk-icon-padded', className)} {...rest} />;
+});
+
+if (__DEV__) {
+  LucideIconPadded.displayName = 'LucideIconPadded';
+}
+
+export default LucideIconPadded;

--- a/packages/icon/src/lucide-icon.tsx
+++ b/packages/icon/src/lucide-icon.tsx
@@ -1,0 +1,41 @@
+import { __DEV__, cx } from '@sk-web-gui/utils';
+import { icons } from 'lucide-react';
+import dynamicIconImports from 'lucide-react/dynamicIconImports';
+import React from 'react';
+import Icon, { type IconProps } from './icon';
+
+type IconNames = keyof typeof dynamicIconImports;
+
+export interface LucideIconProps extends IconProps {
+  name?: IconNames;
+}
+
+function toPascalCase(text: string) {
+  return text.replace(/(^\w|-\w)/g, clearAndUpper);
+}
+
+function clearAndUpper(text: string) {
+  return text.replace(/-/, '').toUpperCase();
+}
+
+export const LucideIcon = React.forwardRef<HTMLSpanElement, LucideIconProps>((props, ref) => {
+  const { name, className, ...rest } = props;
+
+  const LucideIcon = name ? icons[toPascalCase(name) as keyof typeof icons] : undefined;
+
+  return (
+    <Icon
+      ref={ref}
+      className={cx('sk-lucide-icon', className)}
+      icon={LucideIcon ? <LucideIcon /> : undefined}
+      data-testid={name ? `sk-icon-${name}` : undefined}
+      {...rest}
+    />
+  );
+});
+
+if (__DEV__) {
+  LucideIcon.displayName = 'LucideIcon';
+}
+
+export default LucideIcon;

--- a/packages/icon/stories/icon-padded.stories.tsx
+++ b/packages/icon/stories/icon-padded.stories.tsx
@@ -1,15 +1,17 @@
 import { Meta } from '@storybook/react';
-import { Icon, IconProps } from '../src';
+import { IconProps } from '../src/icon';
+import { Check } from 'lucide-react';
+import IconPadded from '../src/icon-padded';
 
 export default {
   title: 'Komponenter/Icon/Icon.Padded',
-  component: Icon.Padded,
+  component: IconPadded,
   tags: ['autodocs'],
   args: {
-    name: 'check',
+    icon: <Check />,
   },
-} as Meta<typeof Icon.Padded>;
+} as Meta<typeof IconPadded>;
 
-export const Template = (props: React.ComponentProps<typeof Icon.Padded>) => <Icon.Padded {...props} />;
+export const Template = (props: IconProps) => <IconPadded {...props} />;
 
 Template.storyName = 'IconPadded';

--- a/packages/icon/stories/icon.stories.tsx
+++ b/packages/icon/stories/icon.stories.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
-import { Icon, IconProps } from '../src/icon';
 import { Meta } from '@storybook/react';
+import { Check } from 'lucide-react';
+import { Icon, IconProps } from '../src/icon';
 
 export default {
-  title: 'Komponenter/Icon',
+  title: 'Komponenter/Icon/Icon',
   component: Icon,
   tags: ['autodocs'],
   args: {
-    name: 'check',
+    icon: <Check />,
   },
 } as Meta<typeof Icon>;
 

--- a/packages/icon/stories/lucide-icon-padded.stories.tsx
+++ b/packages/icon/stories/lucide-icon-padded.stories.tsx
@@ -1,0 +1,16 @@
+import { Meta } from '@storybook/react';
+import { LucideIconProps } from '../src/lucide-icon';
+import LucideIconPadded from '../src/lucide-icon-padded';
+
+export default {
+  title: 'Komponenter/Icon/LucideIcon.Padded',
+  component: LucideIconPadded,
+  tags: ['autodocs'],
+  args: {
+    name: 'check',
+  },
+} as Meta<typeof LucideIconPadded>;
+
+export const Template = (props: LucideIconProps) => <LucideIconPadded {...props} />;
+
+Template.storyName = 'LucideIconPadded';

--- a/packages/icon/stories/lucide-icon.stories.tsx
+++ b/packages/icon/stories/lucide-icon.stories.tsx
@@ -1,0 +1,15 @@
+import { Meta } from '@storybook/react';
+import LucideIcon, { LucideIconProps } from '../src/lucide-icon';
+
+export default {
+  title: 'Komponenter/Icon/LucideIcon',
+  component: LucideIcon,
+  tags: ['autodocs'],
+  args: {
+    name: 'check',
+  },
+} as Meta<typeof LucideIcon>;
+
+export const Template = (props: LucideIconProps) => <LucideIcon {...props} />;
+
+Template.storyName = 'LucideIcon';

--- a/packages/layout/stories/footer.stories.tsx
+++ b/packages/layout/stories/footer.stories.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
+import Icon from '@sk-web-gui/icon';
+import { Link } from '@sk-web-gui/link';
+import { Logo } from '@sk-web-gui/logo';
 import { Meta } from '@storybook/react';
 import { Footer, FooterProps } from '../src';
-import { Link } from '@sk-web-gui/link';
-import { Icon } from '@sk-web-gui/icon';
-import { Logo } from '@sk-web-gui/logo';
 
 export default {
   title: 'Layout/Footer',

--- a/packages/layout/stories/header.stories.tsx
+++ b/packages/layout/stories/header.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Button } from '@sk-web-gui/button';
 import { MenuBar } from '@sk-web-gui/menubar';
-import { Icon } from '@sk-web-gui/icon';
+import Icon from '@sk-web-gui/icon';
 import { PopupMenu } from '@sk-web-gui/popup-menu';
 import { UserMenu, MenuItemGroup } from '@sk-web-gui/user-menu';
 import { Meta, StoryObj } from '@storybook/react';

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -39,7 +39,8 @@
   "dependencies": {
     "@sk-web-gui/icon": "2.0.1",
     "@sk-web-gui/theme": "2.3.1",
-    "@sk-web-gui/utils": "2.0.1"
+    "@sk-web-gui/utils": "2.0.1",
+    "lucide-react": "^0.372.0"
   },
   "peerDependencies": {
     "react": ">=18.2.0"

--- a/packages/link/src/link.tsx
+++ b/packages/link/src/link.tsx
@@ -2,6 +2,7 @@ import { cx, __DEV__, PolymorphicComponentPropsWithRef, PolymorphicRef, DefaultP
 import React from 'react';
 import { useLinkClass } from './styles';
 import { Icon } from '@sk-web-gui/icon';
+import { ExternalLink } from 'lucide-react';
 
 export interface LinkProps extends DefaultProps, React.AnchorHTMLAttributes<HTMLAnchorElement> {
   /** Makes link disabled */
@@ -64,7 +65,7 @@ export const Link = React.forwardRef(
       >
         {children}
         {!hideExternalIcon && external && (
-          <Icon className="sk-link-external-icon" name="external-link" size="fit" variant="ghost" />
+          <Icon className="sk-link-external-icon" icon={<ExternalLink />} size="fit" variant="ghost" />
         )}
       </Comp>
     );

--- a/packages/menu-vertical/package.json
+++ b/packages/menu-vertical/package.json
@@ -40,7 +40,8 @@
     "@sk-web-gui/button": "2.0.9",
     "@sk-web-gui/divider": "1.0.11",
     "@sk-web-gui/icon": "2.0.1",
-    "@sk-web-gui/utils": "2.0.1"
+    "@sk-web-gui/utils": "2.0.1",
+    "lucide-react": "^0.372.0"
   },
   "peerDependencies": {
     "react": ">=18.2.0"

--- a/packages/menu-vertical/src/menu-vertical-backbutton.tsx
+++ b/packages/menu-vertical/src/menu-vertical-backbutton.tsx
@@ -2,6 +2,7 @@ import { Button } from '@sk-web-gui/button';
 import { Icon } from '@sk-web-gui/icon';
 import { DefaultProps, cx } from '@sk-web-gui/utils';
 import React from 'react';
+import { ArrowLeft } from 'lucide-react';
 
 interface IMenuVerticalBackButtonProps extends DefaultProps {
   children: JSX.Element | string;
@@ -17,7 +18,7 @@ export const MenuVerticalBackButton = React.forwardRef<HTMLDivElement, IMenuVert
   return (
     <div ref={ref} className={cx('sk-menu-vertical-backbutton', className)} {...rest}>
       <Button size="lg" variant="tertiary" rounded iconButton>
-        <Icon name="arrow-left" />
+        <Icon icon={<ArrowLeft />} />
       </Button>
       <span>{children}</span>
     </div>

--- a/packages/menu-vertical/src/menu-vertical-submenu-button.tsx
+++ b/packages/menu-vertical/src/menu-vertical-submenu-button.tsx
@@ -3,6 +3,7 @@ import { DefaultProps, __DEV__, cx, getValidChildren } from '@sk-web-gui/utils';
 import React from 'react';
 import { useMenuVertical } from './menu-vertical-context';
 import { IMenuVerticalItemProps } from './menu-vertical-item';
+import { ChevronUp, ChevronDown } from 'lucide-react';
 
 export interface MenuVerticalSubmenuButtonProps extends DefaultProps, Omit<IMenuVerticalItemProps, 'children'> {
   children: string | JSX.Element;
@@ -202,7 +203,7 @@ export const MenuVerticalSubmenuButton: React.FC<MenuVerticalSubmenuButtonProps>
         onClick={disabled ? undefined : handleExpandToggle}
         aria-disabled={disabled ? disabled : undefined}
       >
-        <Icon name={isSubmenuOpen ? 'chevron-up' : 'chevron-down'} />
+        <Icon icon={isSubmenuOpen ? <ChevronUp /> : <ChevronDown />} />
       </button>
     );
   };

--- a/packages/menu-vertical/stories/menu-vertical-sidebar.stories.tsx
+++ b/packages/menu-vertical/stories/menu-vertical-sidebar.stories.tsx
@@ -5,6 +5,7 @@ import { MenuIndex } from '../src/menu-vertical-context';
 import { Icon } from '@sk-web-gui/icon';
 import { Avatar } from '@sk-web-gui/avatar';
 import { Logo } from '@sk-web-gui/logo';
+import { CircleArrowRight } from 'lucide-react';
 
 export default {
   title: 'Komponenter/Sidebar',
@@ -49,7 +50,7 @@ export const Template = (args: MenuVerticalProps) => {
                 <MenuVertical {...args}>
                   <MenuVertical.SubmenuButton>
                     <a href="#">
-                      <Icon name="circle-arrow-right" />
+                      <Icon icon={<CircleArrowRight />} />
                       <span>N1 - Subitem (a-tag)</span>
                     </a>
                   </MenuVertical.SubmenuButton>
@@ -77,7 +78,7 @@ export const Template = (args: MenuVerticalProps) => {
                 <MenuVertical {...args}>
                   <MenuVertical.SubmenuButton>
                     <button>
-                      <Icon name="circle-arrow-right" />
+                      <Icon icon={<CircleArrowRight />} />
                       <span>N1 - Subitem</span>
                     </button>
                   </MenuVertical.SubmenuButton>
@@ -170,7 +171,7 @@ export const Template = (args: MenuVerticalProps) => {
                 <MenuVertical {...args}>
                   <MenuVertical.SubmenuButton disabled>
                     <a href="#">
-                      <Icon name="circle-arrow-right" />
+                      <Icon icon={<CircleArrowRight />} />
                       <span>N1 - Subitem 2</span>
                     </a>
                   </MenuVertical.SubmenuButton>

--- a/packages/menubar/stories/menubar.stories.tsx
+++ b/packages/menubar/stories/menubar.stories.tsx
@@ -3,7 +3,7 @@ import { Meta } from '@storybook/react';
 import { MenuBar, MenuBarProps } from '../src';
 import { Button } from '@sk-web-gui/button';
 import { PopupMenu } from '@sk-web-gui/popup-menu';
-import { Icon } from '@sk-web-gui/icon';
+import Icon from '@sk-web-gui/icon';
 
 export default {
   title: 'Komponenter/Menu-horizontal',

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -40,7 +40,8 @@
     "@headlessui/react": "^1.7.19",
     "@sk-web-gui/button": "2.0.9",
     "@sk-web-gui/icon": "2.0.1",
-    "@sk-web-gui/utils": "2.0.1"
+    "@sk-web-gui/utils": "2.0.1",
+    "lucide-react": "^0.372.0"
   },
   "peerDependencies": {
     "react": ">=18.2.0"

--- a/packages/modal/src/confirm/confirm.tsx
+++ b/packages/modal/src/confirm/confirm.tsx
@@ -3,6 +3,7 @@ import { Icon } from '@sk-web-gui/icon';
 import { __DEV__, cx } from '@sk-web-gui/utils';
 import React from 'react';
 import { Dialog } from '../dialog';
+import { Lightbulb, CircleAlert, CircleHelp } from 'lucide-react';
 
 type UseDialogShowReturnType = {
   show: boolean;
@@ -100,11 +101,11 @@ export const ConfirmationDialogContextProvider: React.FC<ConfirmationDialogConte
   const switchIcon = (parameter: string) => {
     switch (parameter) {
       case 'info':
-        return <Icon rounded name="lightbulb" color={content?.dialogType} />;
+        return <Icon rounded icon={<Lightbulb />} color={content?.dialogType} />;
       case 'error':
-        return <Icon rounded name="circle-alert" color={content?.dialogType} />;
+        return <Icon rounded icon={<CircleAlert />} color={content?.dialogType} />;
       case 'question':
-        return <Icon rounded name="circle-help" color={content?.dialogType} />;
+        return <Icon rounded icon={<CircleHelp />} color={content?.dialogType} />;
       default:
         return null;
     }

--- a/packages/modal/src/modal/modal.tsx
+++ b/packages/modal/src/modal/modal.tsx
@@ -3,6 +3,7 @@ import { Button } from '@sk-web-gui/button';
 import { Icon } from '@sk-web-gui/icon';
 import { DefaultProps, __DEV__, cx } from '@sk-web-gui/utils';
 import React from 'react';
+import { X } from 'lucide-react';
 
 export interface ModalComponentProps
   extends DefaultProps,
@@ -124,7 +125,7 @@ export const ModalComponent = React.forwardRef<HTMLDivElement, ModalComponentPro
                         onClick={onCloseHandler}
                         {...closeButtonProps}
                       >
-                        <Icon name="x" />
+                        <Icon icon={<X />} />
                       </Button>
                     )}
                   </div>

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -41,7 +41,8 @@
     "@sk-web-gui/forms": "2.1.0",
     "@sk-web-gui/icon": "2.0.1",
     "@sk-web-gui/theme": "2.3.1",
-    "@sk-web-gui/utils": "2.0.1"
+    "@sk-web-gui/utils": "2.0.1",
+    "lucide-react": "^0.372.0"
   },
   "peerDependencies": {
     "react": ">=18.2.0"

--- a/packages/pagination/src/pagination.tsx
+++ b/packages/pagination/src/pagination.tsx
@@ -4,6 +4,7 @@ import { usePaginationClass } from './styles';
 import { Select } from '@sk-web-gui/forms';
 import { Icon } from '@sk-web-gui/icon';
 import { Button } from '@sk-web-gui/button';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
 
 export interface PaginationProps extends DefaultProps, React.ComponentPropsWithRef<'div'> {
   /* Total amount of pages */
@@ -263,7 +264,7 @@ export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>((pro
             {prevNextButton({
               next: false,
               label: prevLabel,
-              icon: <Icon name="arrow-left" size="fit" />,
+              icon: <Icon icon={<ArrowLeft />} size="fit" />,
               triggerNumber: minPage,
               step: -1,
               tabIndex: activePage == pages ? undefined : -1,
@@ -305,7 +306,7 @@ export const Pagination = React.forwardRef<HTMLDivElement, PaginationProps>((pro
             {prevNextButton({
               next: true,
               label: nextLabel,
-              icon: <Icon name="arrow-right" size="fit" />,
+              icon: <Icon icon={<ArrowRight />} size="fit" />,
               triggerNumber: pages,
               step: 1,
               tabIndex: activePage == pages ? -1 : undefined,

--- a/packages/popup-menu/stories/popup-menu.stories.tsx
+++ b/packages/popup-menu/stories/popup-menu.stories.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@sk-web-gui/button';
 import { Checkbox, DatePicker, FormControl, FormLabel } from '@sk-web-gui/forms';
-import { Icon } from '@sk-web-gui/icon';
+import Icon from '@sk-web-gui/icon';
 import { Link } from '@sk-web-gui/link';
 import { SearchField } from '@sk-web-gui/searchfield';
 import { Meta } from '@storybook/react';

--- a/packages/progress-stepper/package.json
+++ b/packages/progress-stepper/package.json
@@ -40,7 +40,8 @@
     "@sk-web-gui/divider": "1.0.11",
     "@sk-web-gui/icon": "2.0.1",
     "@sk-web-gui/theme": "2.3.1",
-    "@sk-web-gui/utils": "2.0.1"
+    "@sk-web-gui/utils": "2.0.1",
+    "lucide-react": "^0.372.0"
   },
   "peerDependencies": {
     "react": ">=18.2.0"

--- a/packages/progress-stepper/src/progress-step.tsx
+++ b/packages/progress-stepper/src/progress-step.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { __DEV__, cx } from '@sk-web-gui/utils';
 import { Divider } from '@sk-web-gui/divider';
 import { Icon } from '@sk-web-gui/icon';
+import { Check } from 'lucide-react';
 
 interface ProgressStepProps {
   number: number;
@@ -23,7 +24,7 @@ export const ProgressStep: React.FC<ProgressStepProps> = (props) => {
           className={cx('sk-progress-stepper-step-box', `sk-progress-stepper-step-box-${size}`)}
           data-rounded={rounded}
         >
-          {done ? <Icon name="check" /> : number}
+          {done ? <Icon icon={<Check />} /> : number}
         </div>
         <Divider orientation="horizontal" />
       </div>

--- a/packages/searchfield/package.json
+++ b/packages/searchfield/package.json
@@ -37,7 +37,8 @@
     "@sk-web-gui/button": "2.0.9",
     "@sk-web-gui/forms": "2.1.0",
     "@sk-web-gui/icon": "2.0.1",
-    "@sk-web-gui/utils": "2.0.1"
+    "@sk-web-gui/utils": "2.0.1",
+    "lucide-react": "^0.372.0"
   },
   "devDependencies": {
     "react": "^18.2.0"

--- a/packages/searchfield/src/searchfield.tsx
+++ b/packages/searchfield/src/searchfield.tsx
@@ -3,6 +3,7 @@ import { Input, InputProps } from '@sk-web-gui/forms';
 import { Icon } from '@sk-web-gui/icon';
 import { DefaultProps, __DEV__ } from '@sk-web-gui/utils';
 import React from 'react';
+import { Search, X } from 'lucide-react';
 
 export interface SearchFieldBaseProps
   extends DefaultProps,
@@ -45,8 +46,8 @@ export const SearchFieldBase = React.forwardRef<HTMLInputElement, SearchFieldBas
     className = '',
     searchLabel = 'Sök',
     resetAriaLabel = 'Rensa',
-    searchIcon = <Icon name="search" />,
-    resetIcon = <Icon name="x" />,
+    searchIcon = <Icon icon={<Search />} />,
+    resetIcon = <Icon icon={<X />} />,
     ...rest
   } = props;
 

--- a/packages/snackbar/package.json
+++ b/packages/snackbar/package.json
@@ -40,7 +40,8 @@
     "@sk-web-gui/button": "2.0.9",
     "@sk-web-gui/icon": "2.0.1",
     "@sk-web-gui/toast": "1.0.11",
-    "@sk-web-gui/utils": "2.0.1"
+    "@sk-web-gui/utils": "2.0.1",
+    "lucide-react": "^0.372.0"
   },
   "peerDependencies": {
     "react": ">=18.2.0"

--- a/packages/snackbar/src/snackbar.tsx
+++ b/packages/snackbar/src/snackbar.tsx
@@ -2,34 +2,35 @@ import { Button } from '@sk-web-gui/button';
 import { Icon, IconProps } from '@sk-web-gui/icon';
 import { createToast, useToastOptions } from '@sk-web-gui/toast';
 import { __DEV__, cx as clsx } from '@sk-web-gui/utils';
+import { Lightbulb, Check, AlertTriangle, AlertCircle } from 'lucide-react';
 import React from 'react';
 
 interface Status {
   [key: string]: {
-    icon: IconProps['name'];
+    icon: React.ComponentProps<IconProps['Component']>['icon'];
     cx: string;
   };
 }
 
 const statuses: Status = {
   primary: {
-    icon: 'lightbulb',
+    icon: <Lightbulb />,
     cx: 'sk-snackbar-primary',
   },
   info: {
-    icon: 'lightbulb',
+    icon: <Lightbulb />,
     cx: 'sk-snackbar-info',
   },
   success: {
-    icon: 'check',
+    icon: <Check />,
     cx: 'sk-snackbar-success',
   },
   warning: {
-    icon: 'alert-triangle',
+    icon: <AlertTriangle />,
     cx: 'sk-snackbar-warning',
   },
   error: {
-    icon: 'alert-circle',
+    icon: <AlertCircle />,
     cx: 'sk-snackbar-error',
   },
 };
@@ -95,13 +96,7 @@ export const Snackbar = React.forwardRef<HTMLDivElement, SnackbarProps>((props, 
           (CustomIcon ? (
             <CustomIcon />
           ) : (
-            <Icon
-              variant="ghost"
-              inverted
-              size="fit"
-              name={icon as React.ComponentProps<typeof Icon>['name']}
-              className={clsx('sk-snackbar-icon')}
-            />
+            <Icon variant="ghost" inverted size="fit" icon={icon} className={clsx('sk-snackbar-icon')} />
           ))}
         <span className={clsx('sk-snackbar-text')}>{message}</span>
       </span>

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -43,7 +43,8 @@
     "@sk-web-gui/theme": "2.3.1",
     "@sk-web-gui/utils": "2.0.1",
     "lodash": "^4.17.21",
-    "usehooks-ts": "^3.1.0"
+    "usehooks-ts": "^3.1.0",
+    "lucide-react": "^0.372.0"
   },
   "peerDependencies": {
     "react": ">=18.2.0"

--- a/packages/table/src/table-sort-button.tsx
+++ b/packages/table/src/table-sort-button.tsx
@@ -2,6 +2,7 @@ import { Icon } from '@sk-web-gui/icon';
 import { DefaultProps } from '@sk-web-gui/utils';
 import React from 'react';
 import { SortMode } from './auto-table';
+import { ChevronUp, ChevronDown } from 'lucide-react';
 
 export interface ITableSortButtonProps extends DefaultProps, React.ComponentPropsWithoutRef<'button'> {
   isActive: boolean;
@@ -16,13 +17,13 @@ export const TableSortButton = React.forwardRef<HTMLButtonElement, ITableSortBut
       <div className="sk-table-sortbutton-icon">
         {isActive ? (
           <span className="sk-table-sortbutton-icon-sort" data-sortmode={isActive ? sortOrder : undefined}>
-            <Icon name="chevron-up" size="fit" />
-            <Icon name="chevron-down" size="fit" />
+            <Icon icon={<ChevronUp />} size="fit" />
+            <Icon icon={<ChevronDown />} size="fit" />
           </span>
         ) : (
           <span className="sk-table-sortbutton-icon-sort">
-            <Icon name="chevron-up" size="fit" />
-            <Icon name="chevron-down" size="fit" />
+            <Icon icon={<ChevronUp />} size="fit" />
+            <Icon icon={<ChevronDown />} size="fit" />
           </span>
         )}
       </div>

--- a/packages/table/stories/autotable.stories.tsx
+++ b/packages/table/stories/autotable.stories.tsx
@@ -1,9 +1,7 @@
-import { Meta } from '@storybook/react';
-import React from 'react';
-import { AutoTableHeader } from '../src/auto-table';
 import { Button } from '@sk-web-gui/button';
-import { Icon } from '@sk-web-gui/icon';
-import { AutoTable, AutoTableProps } from '../src/auto-table';
+import Icon from '@sk-web-gui/icon';
+import { Meta } from '@storybook/react';
+import { AutoTable, AutoTableHeader, AutoTableProps } from '../src/auto-table';
 
 export default {
   title: 'Komponenter/Table/AutoTable',

--- a/packages/table/stories/table.stories.tsx
+++ b/packages/table/stories/table.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/react';
 import React from 'react';
 import { Table, TableProps } from '../src';
-import { Icon } from '@sk-web-gui/icon';
+import Icon from '@sk-web-gui/icon';
 import { Button } from '@sk-web-gui/button';
 import { SortMode } from '../src/auto-table';
 import { Input, Select } from '@sk-web-gui/forms';

--- a/packages/text/stories/text.stories.tsx
+++ b/packages/text/stories/text.stories.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import { Text, TextProps } from '../src';
-import { Meta } from '@storybook/react';
 import { Button } from '@sk-web-gui/button';
-import { Icon } from '@sk-web-gui/icon';
+import Icon from '@sk-web-gui/icon';
+import { Meta } from '@storybook/react';
+import { Text, TextProps } from '../src';
 const text =
   'Hej!\n\nDenna komponent hanterar line feed (n) och carriage return (r). \nDen kan också hantera länkar; om du t.ex. skriver https://sundsvall.se, så blir den klickbar. \r\n\r\n/Utvecklingsfabriken';
 export default {

--- a/packages/tooltip/stories/tooltip.stories.tsx
+++ b/packages/tooltip/stories/tooltip.stories.tsx
@@ -1,7 +1,7 @@
 import { Tooltip, TooltipProps } from '../src';
 import { Meta } from '@storybook/react';
 import { Button } from '@sk-web-gui/button';
-import { Icon } from '@sk-web-gui/icon';
+import Icon from '@sk-web-gui/icon';
 import React from 'react';
 
 export default {

--- a/packages/user-menu/stories/user-menu.stories.tsx
+++ b/packages/user-menu/stories/user-menu.stories.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
+import { Link, LucideIcon, MenuItemGroup, UserMenu, UserMenuProps } from '@sk-web-gui/react';
 import { cx } from '@sk-web-gui/utils';
 import { Meta } from '@storybook/react';
-import { UserMenu, Link, Icon, MenuItemGroup, UserMenuProps } from '@sk-web-gui/react';
 
 export default {
   title: 'Komponenter/UserMenu',
@@ -23,7 +22,7 @@ const menuGroups: MenuItemGroup[] = [
         label: 'Min profil',
         element: () => (
           <Link href="/pagaende">
-            <Icon name="user" />
+            <LucideIcon name="user" />
             Profil
           </Link>
         ),
@@ -32,7 +31,7 @@ const menuGroups: MenuItemGroup[] = [
         label: 'Konto',
         element: () => (
           <Link href="/beslutade">
-            <Icon name="wallet" />
+            <LucideIcon name="wallet" />
             Konto
           </Link>
         ),
@@ -41,7 +40,7 @@ const menuGroups: MenuItemGroup[] = [
         label: 'Inställningar',
         element: () => (
           <Link href="/handlingsplan">
-            <Icon name="settings-2" />
+            <LucideIcon name="settings-2" />
             Inställningar
           </Link>
         ),
@@ -55,7 +54,7 @@ const menuGroups: MenuItemGroup[] = [
         label: 'Logga ut',
         element: () => (
           <Link href="/myaccount">
-            <Icon name="log-out" /> Mina uppgifter{' '}
+            <LucideIcon name="log-out" /> Mina uppgifter{' '}
           </Link>
         ),
       },


### PR DESCRIPTION
Removed `name` prop from `<Icon>`.
New component, `<LucideIcon>`, with old behavior.

- Using `<Icon>` with `icon` prop now only include imported and used icons in build.
- Using `<LucideIcon>` with `name` prop will still include all Lucide icons in build.