### PR TITLE
feat: input props in context

### DIFF
--- a/packages/core/src/components/search-field.ts
+++ b/packages/core/src/components/search-field.ts
@@ -5,6 +5,7 @@ export const SearchField = () => ({
     },
     '.sk-form-combobox': {
       '&-list': {
+        '@apply w-full': {},
         '&-option': {
           '.sk-icon': {
             '@apply hidden': {},

--- a/packages/forms/src/combobox/combobox-context.ts
+++ b/packages/forms/src/combobox/combobox-context.ts
@@ -1,3 +1,4 @@
+import { CustomOnChangeEvent } from '@sk-web-gui/utils';
 import React from 'react';
 
 export interface UseComboboxProps {
@@ -12,6 +13,43 @@ export interface UseComboboxProps {
    * @default true
    */
   autofilter?: boolean;
+  /**
+   * Show selected first in list
+   * @default true
+   */
+  sortSelectedFirst?: boolean;
+  /**
+   * Placeholder when search is active
+   */
+  searchPlaceholder?: string;
+  /**
+   * Placeholder when no value is selected
+   */
+  placeholder?: string;
+  /**
+   * Search input value
+   */
+  searchValue?: string;
+  /**
+   * ChangeEvent list
+   */
+  onChange?: (event: CustomOnChangeEvent) => void;
+  /**
+   * ChangeEvent list
+   */
+  onSelect?: (event: CustomOnChangeEvent) => void;
+  /**
+   * ChangeEvent list
+   */
+  onChangeSearch?: (event: CustomOnChangeEvent<string>) => void;
+  /**
+   * Selected value
+   */
+  value?: string | string[];
+  /**
+   * Sets initial value
+   */
+  defaultValue?: string | string[];
 }
 
 interface UseComboboxData extends UseComboboxProps {

--- a/packages/forms/src/combobox/combobox-input.tsx
+++ b/packages/forms/src/combobox/combobox-input.tsx
@@ -10,40 +10,8 @@ interface InputCompProps extends React.InputHTMLAttributes<HTMLInputElement> {
 }
 
 export interface ComboboxInputProps
-  extends UseComboboxProps,
-    Omit<React.ComponentPropsWithRef<'input'>, 'size' | 'onChange' | 'onSelect'> {
-  /**
-   * ChangeEvent list
-   */
-  onChange?: (event: CustomOnChangeEvent) => void;
-  /**
-   * ChangeEvent list
-   */
-  onSelect?: (event: CustomOnChangeEvent) => void;
-  /**
-   * ChangeEvent list
-   */
-  onChangeSearch?: (event: CustomOnChangeEvent<string>) => void;
-  /**
-   * Selected value
-   */
-  value?: string | string[];
-  /**
-   * Sets initial value
-   */
-  defaultValue?: string | string[];
-  /**
-   * Search input value
-   */
-  searchValue?: string;
-  /**
-   * Placeholder when search is active
-   */
-  searchPlaceholder?: string;
-  /**
-   * @default primary
-   */
-  variant?: 'primary' | 'tertiary';
+  extends Omit<UseComboboxProps, 'autofilter' | 'sortSelectedFirst'>,
+    Omit<React.ComponentPropsWithRef<'input'>, 'size' | 'onChange' | 'onSelect' | 'value' | 'defaultValue'> {
   /* Makes input invalid */
   disabled?: boolean;
   invalid?: boolean;
@@ -61,12 +29,13 @@ export const ComboboxInput = React.forwardRef<HTMLInputElement, ComboboxInputPro
     onChange,
     onChangeSearch,
     onSelect,
-    placeholder,
-    searchPlaceholder,
+    placeholder: _placeholder,
+    searchPlaceholder: _searchPlaceholder,
     size: _size,
     invalid: _invalid,
-    variant = 'primary',
+    variant: _variant,
     InputComp,
+    name: _name,
     ...rest
   } = props;
 
@@ -79,6 +48,7 @@ export const ComboboxInput = React.forwardRef<HTMLInputElement, ComboboxInputPro
     labels,
     next,
     prev,
+    close,
     setActive,
     open,
     setOpen,
@@ -86,6 +56,10 @@ export const ComboboxInput = React.forwardRef<HTMLInputElement, ComboboxInputPro
     id: _useId,
     size: _useSize,
     multiple,
+    name: contextName,
+    searchPlaceholder: contextSearchPlaceholder,
+    placeholder: contextPlaceholder,
+    variant: contextVariant,
   } = useCombobox();
 
   const value = contextValue || _incomingValue || '';
@@ -112,15 +86,18 @@ export const ComboboxInput = React.forwardRef<HTMLInputElement, ComboboxInputPro
     hasHelpText,
     size: fcSize,
     id: fcId,
-    name,
+    name: fcName,
   } = useFormControl(props);
 
   const autoId = React.useId();
   const id = _id || _useId || fcId || `sk-form-combobox-${autoId}`;
-
+  const name = _name || contextName || fcName;
   const disabled = _disabled !== undefined ? _disabled : fcDisabled;
   const size = _size || _useSize || fcSize || 'md';
   const invalid = _invalid !== undefined ? _invalid : formcontrolInvalid;
+  const placeholder = _placeholder || contextPlaceholder;
+  const searchPlaceholder = _searchPlaceholder || contextSearchPlaceholder;
+  const variant = _variant || contextVariant || 'primary';
   const classes = useComboboxStyles({ size, variant });
 
   React.useEffect(() => {
@@ -134,8 +111,10 @@ export const ComboboxInput = React.forwardRef<HTMLInputElement, ComboboxInputPro
   }, [_incomingValue]);
 
   const [valueMemo, setValueMemo] = React.useState<typeof value | null>(value);
+
   useEffect(() => {
     const _value = value.map((opt) => labels[opt]);
+
     if (_.isEqual(_value, valueMemo) === false) {
       setValueMemo(_value);
       const event = {
@@ -144,10 +123,12 @@ export const ComboboxInput = React.forwardRef<HTMLInputElement, ComboboxInputPro
           name: name ?? '',
         },
       } as CustomOnChangeEvent;
+
       onChange && onChange(event);
       if (multiple || (_value.length && _value[0])) {
         onSelect && onSelect(event);
       }
+
       if (value.length > 0 && value[0]) {
         onChangeSearch && onChangeSearch({ target: { value: '', name: name ?? '' } } as CustomOnChangeEvent<string>);
       }

--- a/packages/forms/src/combobox/combobox-list.tsx
+++ b/packages/forms/src/combobox/combobox-list.tsx
@@ -14,7 +14,7 @@ export const ComboboxList = React.forwardRef<HTMLFieldSetElement, ComboboxListPr
   const internalRef = React.useRef<HTMLFieldSetElement>(null);
   const { className, multiple: _multiple, size: _size, value: _value, children, ...rest } = props;
 
-  const { total, setTotal, open, autofilter, ...context } = useCombobox();
+  const { total, setTotal, open, autofilter, sortSelectedFirst, ...context } = useCombobox();
 
   useOnElementOutside(
     internalRef,
@@ -35,6 +35,8 @@ export const ComboboxList = React.forwardRef<HTMLFieldSetElement, ComboboxListPr
   const multiple = _multiple !== undefined ? _multiple : context.multiple || false;
 
   const sortSelected = (a: React.ReactElement, b: React.ReactElement) => {
+    if (!sortSelectedFirst) return 0;
+
     const achecked =
       a.props.checked !== undefined
         ? a.props.checked
@@ -69,7 +71,7 @@ export const ComboboxList = React.forwardRef<HTMLFieldSetElement, ComboboxListPr
           .map((child, index) =>
             React.cloneElement(child, { ...child.props, index: index, id: `${context.listId}-${index}` })
           );
-  }, [context.searchValue, open, children]);
+  }, [context.searchValue, open]);
 
   useEffect(() => {
     setTotal && setTotal(React.Children.count(options));

--- a/packages/forms/stories/combobox.stories.tsx
+++ b/packages/forms/stories/combobox.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import { Combobox, FormControl, FormErrorMessage, FormHelperText, FormLabel } from '../src';
+import { Combobox, ComboboxProps, FormControl, FormErrorMessage, FormHelperText, FormLabel } from '../src';
 export default {
   title: 'Komponenter/Combobox',
   component: Combobox.Input,
@@ -137,7 +137,7 @@ const fruits = [
   'watermelon',
 ];
 
-export const Template = (args: React.ComponentPropsWithRef<typeof Combobox.Input>) => {
+export const Template = (args: ComboboxProps) => {
   const [value, setValue] = React.useState<string | string[]>('');
 
   const handleOnChange: React.ComponentProps<typeof Combobox.Input>['onChange'] = (e) => {
@@ -151,8 +151,8 @@ export const Template = (args: React.ComponentPropsWithRef<typeof Combobox.Input
 
   return (
     <div className="h-[45rem]">
-      <Combobox>
-        <Combobox.Input {...args} value={value} onChange={handleOnChange} onSelect={handleOnSelect} />
+      <Combobox {...args} value={value} onChange={handleOnChange} onSelect={handleOnSelect}>
+        <Combobox.Input />
         <Combobox.List>
           {fruits.map((fruit, index) => (
             <Combobox.Option key={`fruit-${index}`} value={fruit}>
@@ -167,7 +167,7 @@ export const Template = (args: React.ComponentPropsWithRef<typeof Combobox.Input
 
 Template.storyName = 'Combobox';
 
-export const CustomFilterHandler = (args: React.ComponentPropsWithRef<typeof Combobox.Input>) => {
+export const CustomFilterHandler = (args: ComboboxProps) => {
   const [query, setQuery] = React.useState<string>('');
   const [delayedList, setDelayedList] = React.useState<typeof applesAndPears>([]);
 
@@ -185,15 +185,16 @@ export const CustomFilterHandler = (args: React.ComponentPropsWithRef<typeof Com
     <div className="h-[40rem]">
       <FormControl>
         <FormLabel>Favoritfrukt</FormLabel>
-        <Combobox autofilter={false}>
-          <Combobox.Input
-            {...args}
-            searchPlaceholder="Search apple or pear"
-            searchValue={query}
-            defaultValue={delayedList.length > 0 ? delayedList[0].id.toString() : ''}
-            onChange={handleOnChange}
-            onChangeSearch={(e) => setQuery(e.target.value.toLowerCase())}
-          />
+        <Combobox
+          autofilter={false}
+          {...args}
+          searchPlaceholder="Search apple or pear"
+          searchValue={query}
+          defaultValue={delayedList.length > 0 ? delayedList[0].id.toString() : ''}
+          onChange={handleOnChange}
+          onChangeSearch={(e) => setQuery(e.target.value.toLowerCase())}
+        >
+          <Combobox.Input />
           <Combobox.List>
             {delayedList
               .filter((fruit) => fruit.name.toLowerCase().includes(query) || fruit.type.includes(query))
@@ -209,7 +210,7 @@ export const CustomFilterHandler = (args: React.ComponentPropsWithRef<typeof Com
   );
 };
 
-export const SingleChoiceWithForm = (args: React.ComponentPropsWithRef<typeof Combobox.Input>) => {
+export const SingleChoiceWithForm = (args: ComboboxProps) => {
   const { register, formState, watch } = useForm<{ fruit: string }>({ defaultValues: { fruit: 'lime' } });
   const myfruit = watch().fruit;
   React.useEffect(() => {
@@ -220,13 +221,13 @@ export const SingleChoiceWithForm = (args: React.ComponentPropsWithRef<typeof Co
     <div className="h-[40rem]">
       <FormControl>
         <FormLabel>Favoritfrukt</FormLabel>
-        <Combobox>
-          <Combobox.Input
-            {...args}
-            placeholder="Välj en frukt"
-            {...register('fruit')}
-            defaultValue={formState?.defaultValues?.fruit}
-          />
+        <Combobox
+          {...args}
+          placeholder="Välj en frukt"
+          {...register('fruit')}
+          defaultValue={formState?.defaultValues?.fruit}
+        >
+          <Combobox.Input />
           <Combobox.List>
             {fruits.map((fruit) => (
               <Combobox.Option key={`singlefruit-${fruit}`} value={fruit}>
@@ -241,7 +242,7 @@ export const SingleChoiceWithForm = (args: React.ComponentPropsWithRef<typeof Co
   );
 };
 
-export const MultipleChoicesWithForm = (args: React.ComponentPropsWithRef<typeof Combobox.Input>) => {
+export const MultipleChoicesWithForm = (args: ComboboxProps) => {
   const {
     register,
     setError,
@@ -263,8 +264,8 @@ export const MultipleChoicesWithForm = (args: React.ComponentPropsWithRef<typeof
     <div className="h-[40rem]">
       <FormControl required invalid={!!errors.fruits}>
         <FormLabel>Favoritfrukt</FormLabel>
-        <Combobox multiple>
-          <Combobox.Input {...args} {...register('fruits')} placeholder="Välj en frukt" />
+        <Combobox multiple {...args} {...register('fruits')} placeholder="Välj en frukt">
+          <Combobox.Input />
           <Combobox.List>
             {fruits.map((fruit) => (
               <Combobox.Option key={`multifruit-${fruit}`} value={fruit}>


### PR DESCRIPTION
Bugfix:
- Unused context props spread on input (unknown html attr error)

Feat:
- Input props in context

Control input from context OR input component. 
Before (in stories) you could not control all settings. Depending on args spread on `Combobox` or `Combobox.Input`. 
The input component will now inherit props from context, but if needed, you can still set them directly on the component.