### PR TITLE
fix(combobox): prevent infinite render loop when value is set via props

### DIFF
--- a/packages/forms/src/combobox/combobox.tsx
+++ b/packages/forms/src/combobox/combobox.tsx
@@ -41,6 +41,8 @@ export const ComboboxBase = React.forwardRef<HTMLInputElement, ComboboxBaseProps
 
   const internalRef = React.useRef<HTMLInputElement>(null);
   const inputRef = React.useRef<HTMLInputElement>(null);
+  const isPropSyncRef = React.useRef(false);
+  const isInitialMountRef = React.useRef(true);
 
   const { id: fcId, size: fcSize, name: fcName } = useFormControl(props);
 
@@ -63,6 +65,14 @@ export const ComboboxBase = React.forwardRef<HTMLInputElement, ComboboxBaseProps
   }, [searchValue]);
 
   React.useEffect(() => {
+    if (isInitialMountRef.current) {
+      isInitialMountRef.current = false;
+      return;
+    }
+    if (isPropSyncRef.current) {
+      isPropSyncRef.current = false;
+      return;
+    }
     const event = {
       target: {
         value: multiple ? internalValue : internalValue.length ? internalValue.join('') : '',
@@ -155,6 +165,7 @@ export const ComboboxBase = React.forwardRef<HTMLInputElement, ComboboxBaseProps
 
   React.useEffect(() => {
     if (value?.toString() !== internalValue.toString()) {
+      isPropSyncRef.current = true;
       if (typeof value === 'string') {
         setInternalValue([value]);
       }

--- a/packages/forms/stories/combobox.stories.tsx
+++ b/packages/forms/stories/combobox.stories.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
+import _ from 'lodash';
 import { Combobox, ComboboxProps, FormControl, FormErrorMessage, FormHelperText, FormLabel } from '../src';
 import { Button } from '@sk-web-gui/button';
 export default {
@@ -284,39 +285,64 @@ export const SingleChoiceWithForm = (args: ComboboxProps) => {
   );
 };
 
-export const MultipleChoicesWithForm = (args: ComboboxProps) => {
-  const {
-    register,
-    setError,
-    clearErrors,
-    watch,
-    formState: { errors },
-  } = useForm<{ fruits: string[] }>();
-  const myfruits = watch().fruits;
-  React.useEffect(() => {
-    console.log('myfruits', myfruits);
-    if (myfruits && myfruits.length < 1) {
-      setError('fruits', { message: 'Välj minst en frukt' });
-    } else {
-      clearErrors('fruits');
+/**
+ * Simulates RJSF Form behavior: a class component that fires onChange
+ * from a setState callback whenever it receives new formData via props.
+ * This mirrors how @rjsf/core Form calls props.onChange from
+ * commitClassCallbacks during the React commit phase.
+ */
+class FormLikeWrapper extends React.Component<{
+  formData: Record<string, any>;
+  onChange: (e: { formData: Record<string, any> }) => void;
+  children: (formData: Record<string, any>) => React.ReactNode;
+}> {
+  state = { formData: this.props.formData };
+
+  componentDidUpdate(prevProps: typeof this.props) {
+    if (!_.isEqual(prevProps.formData, this.props.formData)) {
+      const newFormData = { ...this.props.formData };
+      this.setState({ formData: newFormData }, () => {
+        this.props.onChange({ formData: { ...this.state.formData } });
+      });
     }
-  }, [myfruits]);
+  }
+
+  render() {
+    return this.props.children(this.state.formData);
+  }
+}
+
+export const MultipleChoicesWithForm = (args: ComboboxProps) => {
+  const [formData, setFormData] = React.useState<Record<string, any>>({ fruits: ['banana', 'cherry'] });
+
+  const handleFormChange = React.useCallback((e: { formData: Record<string, any> }) => {
+    setFormData({ ...e.formData });
+  }, []);
 
   return (
     <div className="h-[40rem]">
-      <FormControl required invalid={!!errors.fruits}>
+      <FormControl required>
         <FormLabel>Favoritfrukt</FormLabel>
-        <Combobox multiple {...args} {...register('fruits')} placeholder="Välj en frukt">
-          <Combobox.Input />
-          <Combobox.List>
-            {fruits.map((fruit) => (
-              <Combobox.Option key={`multifruit-${fruit}`} value={fruit}>
-                {fruit}
-              </Combobox.Option>
-            ))}
-          </Combobox.List>
-        </Combobox>
-        {errors.fruits && <FormErrorMessage>Välj minst en frukt</FormErrorMessage>}
+        <FormLikeWrapper formData={formData} onChange={handleFormChange}>
+          {(fd) => (
+            <Combobox
+              multiple
+              {...args}
+              value={fd.fruits}
+              onChange={(e) => setFormData((prev) => ({ ...prev, fruits: e.target.value }))}
+              placeholder="Välj en frukt"
+            >
+              <Combobox.Input />
+              <Combobox.List>
+                {fruits.map((fruit) => (
+                  <Combobox.Option key={`multifruit-${fruit}`} value={fruit}>
+                    {fruit}
+                  </Combobox.Option>
+                ))}
+              </Combobox.List>
+            </Combobox>
+          )}
+        </FormLikeWrapper>
       </FormControl>
     </div>
   );


### PR DESCRIPTION
The Combobox component called onChange from a useEffect on internalValue, which triggered infinite loops when used with form libraries like RJSF that re-fire onChange from componentDidUpdate. Added isPropSyncRef and isInitialMountRef guards so onChange only fires from user interactions, not from prop synchronization or initial mount.

Updated MultipleChoicesWithForm story to reproduce the bug using a FormLikeWrapper class component that simulates RJSF's behavior.

Jira https://jira.sundsvall.se/browse/UF-18317

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).
