### PR TITLE
fix: handles evaluation error in storybook start up

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -2,15 +2,9 @@ import type { StorybookConfig } from '@storybook/react-vite';
 import react from '@vitejs/plugin-react';
 import fs from 'node:fs';
 import path from 'node:path';
-import { createRequire } from 'node:module';
-import { fileURLToPath } from 'node:url';
 import { mergeConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { reloadStylesOnFolderChange } from './utils.ts';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const require = createRequire(import.meta.url);
 
 function getPackages() {
   const packagesPath = path.resolve(__dirname, '../packages');


### PR DESCRIPTION
### Bakgrund
yarn dev kraschar med _ReferenceError: require is not defined_

### Vad som hände

`yarn dev` stannade på `MainFileEvaluationError` när Storybook försökt köra _.storybook/main.ts_. Stack-trace'n pekade på denna rad:

```
const __esbuild_register_import_meta_url__ = require('url').pathToFileURL(__filename).href;
````

Det är esbuild-registers "shim"/fix för `import.meta.url`. Den shim:en är CJS, men eftersom filen samtidigt innehåller import-statements klassar Node hela filen som ESM (via `loadESMFromCJS`) — och då finns require inte längre. Klassisk halvtransformation.

`yarn build` påverkades inte eftersom Lerna inte rör Storybook

Tidigare fix (_5edd65c1 "chore: ts build import issues"_) - den commit'en skrev om _main.ts_ till mer ESM-strikt stil och la till:

```
import { createRequire } from 'node:module';
import { fileURLToPath } from 'node:url';

const __filename = fileURLToPath(import.meta.url);
const __dirname = path.dirname(__filename);
const require = createRequire(import.meta.url);
```

Tanken var rimlig (få `__dirname` och `require` på ett ESM-säkert sätt), men just `import.meta.url` är det som triggar esbuild-registers shim. Före committen kompilerade esbuild-register hela filen till CJS och `__dirname/require` fanns.

### Den här fixen

Backar de fem ESM-specifika raderna. `__dirname` och `require` är åter tillgängliga via esbuild-registers CJS-wrapping, precis som innan committen. Inga andra ändringar: _node:fs/node:path/./utils.ts_ får ligga kvar.
