### PR TITLE
fix(alert): forward ref in AlertIcon render function

### DIFF
--- a/packages/alert/src/alert-icon.tsx
+++ b/packages/alert/src/alert-icon.tsx
@@ -18,9 +18,11 @@ const translateIconSize = (size: string) => {
   }
 };
 
-export const AlertIcon = React.forwardRef<HTMLSpanElement, AlertIconProps>((props) => {
+export const AlertIcon = React.forwardRef<HTMLSpanElement, AlertIconProps>((props, ref) => {
   const { size: iconSize, icon, iconColor } = useAlert();
   const { className, size = translateIconSize(iconSize), ...rest } = props;
 
-  return <Icon icon={icon} color={iconColor} size={size} className={cx('sk-alert-icon', className)} {...rest} />;
+  return (
+    <Icon ref={ref} icon={icon} color={iconColor} size={size} className={cx('sk-alert-icon', className)} {...rest} />
+  );
 });


### PR DESCRIPTION
## Problem

`AlertIcon` förlitade sig på `React.forwardRef` men render-funktionen deklarerade bara `props` — `ref`-parametern saknades. React loggar då varningen:

> forwardRef render functions accept exactly two parameters: props and ref. Did you forget to use the ref parameter?

Varningen syns i konsumerande appar (t.ex. errand) eftersom `AlertIcon` renderas inuti `Alert`.

## Fix

`AlertIcon` tar nu emot `ref` som andra parameter och forward:ar den till det underliggande `Icon` (typat som `HTMLSpanElement`, vilket matchar `Icon`s egen `forwardRef`-signatur).

## Scope

Endast `packages/alert/src/alert-icon.tsx` (4 +, 2 -). Ingen beteendeförändring utöver att `ref` nu propageras korrekt.