### PR TITLE
fix(docker): raise Node heap limit for the Storybook build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,14 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
+# The Storybook 10 + Vite production build is memory-heavy (react-docgen-typescript
+# builds a full TS program over the monorepo). Without this, Node's default heap cap
+# auto-tunes low on a constrained build host and OOMs mid-build — the crash surfaces
+# at whatever module jiti happens to be evaluating (e.g. packages/core/src/theme.ts),
+# which makes it look unrelated. The app-level NODE_OPTIONS env does NOT reach these
+# RUN steps, so it must be set here. The host still needs ~5 GB free (RAM + swap).
+ENV NODE_OPTIONS="--max-old-space-size=4096"
+
 # Build the styleguide, then generate the component manifest the MCP server reads.
 RUN yarn run boot:storybook
 RUN node mcp-server/generate-manifest.mjs


### PR DESCRIPTION
## Problem

The Dokploy deploy fails at \`RUN yarn run boot:storybook\` with a confusing jiti stack pointing at \`packages/core/src/theme.ts:4\` and \`Storybook exited with an error\`. The build is **not** broken — it's running **out of memory**. A clean \`docker build\` on a machine with ample RAM succeeds; under a ~1.5 GB cap it dies the exact same way the Dokploy log shows. The crash surfaces at whatever module jiti happens to be evaluating when V8 runs out of heap, which makes it look unrelated to memory.

This regressed after the Storybook 8.6 → 10.4 upgrade (#494) — the SB 10 + Vite production build with \`react-docgen-typescript\` (full TS program over the monorepo) needs ~5 GB.

## Why the existing setting didn't help

The Dokploy app has \`NODE_OPTIONS=--max-old-space-size=4096\` set, but only in the **runtime** env. For a Dockerfile build, runtime env vars don't reach \`RUN\` steps (and \`buildArgs\` is empty), so \`boot:storybook\` ran with Node's default heap cap, which auto-tunes low on a constrained host.

## Fix

Set the heap limit as a build-time \`ENV\` in the builder stage so it actually applies during \`boot:storybook\`. Verified: with this flag and ~5 GB available the build completes; at 3 GB it's OOM-killed; at 1.5 GB it reproduces the original failure exactly.

## Required host action (not in this PR)

\`memoryLimit\` is null on the app, so the ceiling is the Dokploy host's physical RAM. The host must have ~5–6 GB available. If it's a small VPS, add swap:

\`\`\`
fallocate -l 4G /swapfile && chmod 600 /swapfile && mkswap /swapfile && swapon /swapfile
echo '/swapfile none swap sw 0 0' >> /etc/fstab
\`\`\`

Without enough backing memory, the raised heap limit just trades the V8 heap error for a kernel SIGKILL.