### PR TITLE
fix(docker): build CJS before Storybook build (fixes the real deploy failure)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clean:dist": "yarn lerna exec rimraf dist",
     "boot": "yarn && yarn build:nocache",
     "boot:esm": "yarn && yarn build:esm:nocache",
-    "boot:storybook": "yarn && lerna run build:esm --no-private --stream --skip-nx-cache && yarn build:storybook",
+    "boot:storybook": "yarn && lerna run build:esm --no-private --stream --skip-nx-cache && lerna run build:cjs --no-private --stream --skip-nx-cache && yarn build:storybook",
     "reboot": "yarn clean:dist | yarn cache clean && yarn boot",
     "dev": "yarn dev-storybook",
     "dev:test": "yarn dev-storybook --test",


### PR DESCRIPTION
## TL;DR

This is the actual fix for the failing Dokploy deploy. #498 (raise heap limit) was a misdiagnosis on my part — harmless and worth keeping as headroom for the SB10 build, but it did **not** fix the deploy.

## The real error

A clean build fails at \`RUN yarn run boot:storybook\` with:

\`\`\`
[vite:css] [postcss] Cannot find module './node_modules/@sk-web-gui/theme/dist/cjs/index.js'
  at jiti (.../jiti.js)
  at ./packages/core/src/theme.ts:4
\`\`\`

Tailwind's **jiti** loader reads \`tailwind.config.ts\` → \`packages/core/src/preset\` → \`theme.ts\`, which imports \`@sk-web-gui/theme\`. jiti resolves packages via the **CJS \`require\` condition** (\`dist/cjs/index.js\`) — but \`boot:storybook\` only ran \`build:esm\`, so \`dist/cjs\` is never produced on a fresh checkout.

It worked on dev machines (and in a naive local \`docker build\`) only because \`dist\` is **not** in \`.dockerignore\`, so a previously-built local \`dist/cjs\` gets copied into the image via \`COPY . .\`. Dokploy's fresh git clone has no \`dist\` (it's git-ignored), so the file is genuinely missing.

## Fix

Build CJS alongside ESM in \`boot:storybook\` before \`storybook build\`. swc's CJS output is cheap and runs sequentially, so it doesn't raise the build's peak memory.

## Verification

Reproduced Dokploy's clean state by adding \`packages/*/dist\` to \`.dockerignore\` and building the \`builder\` stage:
- **Before:** fails with the exact \`Cannot find module .../theme/dist/cjs/index.js\`.
- **After:** \`Storybook build completed successfully\` + manifest generated.

## Follow-up (not in this PR)

In the clean build the manifest reports **67 components with props** vs **71** when \`dist/types\` is present — \`generate-manifest.mjs\` resolves some cross-package prop types via sibling packages' \`dist/types\`, which \`boot:storybook\` doesn't build. If we want full prop coverage in the MCP manifest, we can also run \`build:types\` (slower, heavier). Happy to do that as a separate change if desired.