### PR TITLE
fix: remove vulnerable transitive dependencies

### DIFF
--- a/packages/countrycode-select/package.json
+++ b/packages/countrycode-select/package.json
@@ -39,7 +39,7 @@
     "react": "^19.0.0"
   },
   "dependencies": {
-    "@sk-web-gui/forms": "2.4.5",
+    "@sk-web-gui/forms": "2.9.3",
     "@sk-web-gui/utils": "2.2.2",
     "country-flag-emoji-polyfill": "^0.1.8"
   },

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -50,7 +50,7 @@
     "lucide-react": "^0.537.0",
     "react-hook-form": "^7.62.0",
     "usehooks-ts": "^3.1.1",
-    "uuid": "11.1.0"
+    "uuid": "11.1.1"
   },
   "peerDependencies": {
     "react": ">=18.3.1"

--- a/packages/forms/src/combobox/combobox-input.tsx
+++ b/packages/forms/src/combobox/combobox-input.tsx
@@ -3,7 +3,10 @@ import React from 'react';
 import { useFormControl } from '../form-control';
 import { UseComboboxProps, useCombobox } from './combobox-context';
 import { useComboboxStyles } from './styles';
-import _ from 'lodash';
+
+const isEqualStringArray = (first: readonly string[], second: readonly string[] | null): boolean =>
+  second !== null && first.length === second.length && first.every((value, index) => value === second[index]);
+
 export interface ComboboxInputProps
   extends Omit<UseComboboxProps, 'autofilter' | 'sortSelectedFirst'>,
     Omit<React.ComponentPropsWithRef<'input'>, 'size' | 'onChange' | 'onSelect' | 'value' | 'defaultValue'> {
@@ -113,7 +116,7 @@ export const ComboboxInput = React.forwardRef<HTMLInputElement, ComboboxInputPro
   React.useEffect(() => {
     const _value = value.map((opt) => labels[opt]);
 
-    if (_.isEqual(_value, valueMemo) === false) {
+    if (!isEqualStringArray(_value, valueMemo)) {
       setValueMemo(_value);
       const event = {
         target: {

--- a/packages/forms/stories/combobox.stories.tsx
+++ b/packages/forms/stories/combobox.stories.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import _ from 'lodash';
 import { Combobox, ComboboxProps, FormControl, FormErrorMessage, FormHelperText, FormLabel } from '../src';
 import { Button } from '@sk-web-gui/button';
 export default {
@@ -299,7 +298,7 @@ class FormLikeWrapper extends React.Component<{
   state = { formData: this.props.formData };
 
   componentDidUpdate(prevProps: typeof this.props) {
-    if (!_.isEqual(prevProps.formData, this.props.formData)) {
+    if (JSON.stringify(prevProps.formData) !== JSON.stringify(this.props.formData)) {
       const newFormData = { ...this.props.formData };
       this.setState({ formData: newFormData }, () => {
         this.props.onChange({ formData: { ...this.state.formData } });

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -44,7 +44,6 @@
     "@sk-web-gui/pagination": "1.1.18",
     "@sk-web-gui/theme": "2.7.1",
     "@sk-web-gui/utils": "2.2.2",
-    "lodash": "^4.17.21",
     "lucide-react": "^0.537.0",
     "usehooks-ts": "^3.1.1"
   },

--- a/packages/table/src/auto-table.tsx
+++ b/packages/table/src/auto-table.tsx
@@ -13,6 +13,19 @@ import { TableFooter } from './table-footer';
 import Table, { TableComponentProps } from './table';
 import { SortMode } from './types';
 
+// Formats a property segment as a human-readable header, e.g. 'caseType' -> 'Case type'.
+const humanizeLabel = (label: string): string => {
+  const words = label
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+    .replace(/([a-zA-Z])(\d)/g, '$1 $2')
+    .replace(/(\d)([a-zA-Z])/g, '$1 $2')
+    .toLowerCase()
+    .trim();
+  return words.charAt(0).toUpperCase() + words.slice(1);
+};
+
 //eslint-disable-next-line
 type TableValue = any;
 type TableItem = Record<string | number, TableValue>;
@@ -134,14 +147,14 @@ export const AutoTable = React.forwardRef<HTMLTableElement, AutoTableProps>((pro
     switch (typeof header) {
       case 'string':
         headerparts = header.split('.');
-        return headerparts[headerparts.length - 1];
+        return humanizeLabel(headerparts[headerparts.length - 1]);
 
       default:
         if (header.label) {
           return header.label;
         }
         headerparts = header.property ? header.property.split('.') : [];
-        return headerparts.length ? headerparts[headerparts.length - 1] : '';
+        return headerparts.length ? humanizeLabel(headerparts[headerparts.length - 1]) : '';
     }
   };
 

--- a/packages/table/src/auto-table.tsx
+++ b/packages/table/src/auto-table.tsx
@@ -10,7 +10,6 @@ import { TableBody } from './table-body';
 import { TableRow } from './table-row';
 import { TableRowColumn } from './table-row-column';
 import { TableFooter } from './table-footer';
-import _ from 'lodash';
 import Table, { TableComponentProps } from './table';
 import { SortMode } from './types';
 
@@ -135,14 +134,14 @@ export const AutoTable = React.forwardRef<HTMLTableElement, AutoTableProps>((pro
     switch (typeof header) {
       case 'string':
         headerparts = header.split('.');
-        return _.upperFirst(_.lowerCase(headerparts[headerparts.length - 1]));
+        return headerparts[headerparts.length - 1];
 
       default:
         if (header.label) {
           return header.label;
         }
         headerparts = header.property ? header.property.split('.') : [];
-        return headerparts.length ? _.upperFirst(_.lowerCase(headerparts[headerparts.length - 1])) : '';
+        return headerparts.length ? headerparts[headerparts.length - 1] : '';
     }
   };
 

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -36,12 +36,10 @@
     "lint:src": "eslint src"
   },
   "devDependencies": {
-    "@types/lodash.set": "^4.3.9",
     "react": "^19.0.0"
   },
   "dependencies": {
     "@sk-web-gui/utils": "2.2.2",
-    "lodash.set": "^4.3.2",
     "usehooks-ts": "^3.1.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -805,17 +805,6 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.10.tgz#a2a1e3812d14525f725d011a73eceb41fef5bc1c"
   integrity sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==
 
-"@headlessui/react@^2.2.0":
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-2.2.8.tgz#9c29b90efb827bfde75f4dc8c127b946640f2d0c"
-  integrity sha512-vkiZulDC0lFeTrZTbA4tHvhZHvkUb2PFh5xJ1BvWAZdRK0fayMKO1QEO4inWkXxK1i0I1rcwwu1d6mo0K7Pcbw==
-  dependencies:
-    "@floating-ui/react" "^0.26.16"
-    "@react-aria/focus" "^3.20.2"
-    "@react-aria/interactions" "^3.25.0"
-    "@tanstack/react-virtual" "^3.13.9"
-    use-sync-external-store "^1.5.0"
-
 "@headlessui/react@^2.2.7":
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-2.2.7.tgz#689443e19756f51ecc869866b3cdda19aebc38c3"
@@ -2474,128 +2463,6 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
   integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
 
-"@sk-web-gui/button@2.1.6":
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/@sk-web-gui/button/-/button-2.1.6.tgz#d4e720d08fb2a3c3c002b5c54e5f77fd4170851e"
-  integrity sha512-beTM8xhr0y65nog7Za8gRMX7j5gRvpi2DPrz9BL4xJ+G20MRTOyWQ6W05EBo7yA29w2mMmxMqfHltW9amXfd7A==
-  dependencies:
-    "@sk-web-gui/link" "1.2.5"
-    "@sk-web-gui/spinner" "1.1.6"
-    "@sk-web-gui/theme" "2.5.1"
-    "@sk-web-gui/utils" "2.2.2"
-
-"@sk-web-gui/button@2.1.8":
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/@sk-web-gui/button/-/button-2.1.8.tgz#bca2c0713e90396defffed51457c9f30cc05f149"
-  integrity sha512-9plBVH6x4CIkHo3okhd8+JQ2BxdYa3OVq2VMVcJmBd27uB8xpzBc76rmZRWrJRnHJpdoPi+cbvP71wbIVInRaw==
-  dependencies:
-    "@sk-web-gui/link" "1.2.7"
-    "@sk-web-gui/spinner" "1.1.7"
-    "@sk-web-gui/theme" "2.6.0"
-    "@sk-web-gui/utils" "2.2.2"
-
-"@sk-web-gui/divider@1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@sk-web-gui/divider/-/divider-1.1.5.tgz#92b66fd4107a8ce33acb7e82683969eb561dca4e"
-  integrity sha512-N3sfHovzgKtcWY9U3z2Qd7T8HsT5WSzqZ4VY2aDttT4EgAiHrUdseqKWZCM3bPE+Qjx+L9XAxDy+jSj3ZyJY1A==
-  dependencies:
-    "@sk-web-gui/theme" "2.5.1"
-    "@sk-web-gui/utils" "2.2.2"
-
-"@sk-web-gui/forms@2.4.5":
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/@sk-web-gui/forms/-/forms-2.4.5.tgz#2a1cbd526856eb5f3bda788d3f7e0c10bf899942"
-  integrity sha512-KJOLTPvUDaeE7XrnJ2jLm/xop3VGlkjmnscn89A91+qXFJY0e8TRILA39mmiUaIvlk1vw824ySSEf1kcBCrtaQ==
-  dependencies:
-    "@sk-web-gui/button" "2.1.6"
-    "@sk-web-gui/divider" "1.1.5"
-    "@sk-web-gui/icon" "3.1.2"
-    "@sk-web-gui/link" "1.2.5"
-    "@sk-web-gui/modal" "2.2.6"
-    "@sk-web-gui/popup-menu" "3.1.6"
-    "@sk-web-gui/theme" "2.5.1"
-    "@sk-web-gui/utils" "2.2.2"
-    lucide-react "^0.471.1"
-    react-hook-form "^7.54.2"
-    usehooks-ts "^3.1.1"
-    uuid "11.0.5"
-
-"@sk-web-gui/link@1.2.5":
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/@sk-web-gui/link/-/link-1.2.5.tgz#0559e1020a524385b16329caa2d2826feaafb247"
-  integrity sha512-7qvVi0LeOj3lql458PJ+eOHI4wWfG8DxTYBmf1o89L/BQTAYH+XELLx0IOp7fSp/0rDqqs28XKAfLE9YZY9uAw==
-  dependencies:
-    "@sk-web-gui/icon" "3.1.2"
-    "@sk-web-gui/theme" "2.5.1"
-    "@sk-web-gui/utils" "2.2.2"
-    lucide-react "^0.471.1"
-
-"@sk-web-gui/link@1.2.7":
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/@sk-web-gui/link/-/link-1.2.7.tgz#5c11a520ae0282f598d368d4fd0b43a70df9798a"
-  integrity sha512-deDtNo7ACCyulQIyCEi/0GLGbS+vtQ4rEHbfgxWniS6fpXGqR5iLKLUZ49wc0dK9ar2uRf6NRCDH4Nbo+XHZ8A==
-  dependencies:
-    "@sk-web-gui/icon" "3.1.2"
-    "@sk-web-gui/theme" "2.6.0"
-    "@sk-web-gui/utils" "2.2.2"
-    lucide-react "^0.537.0"
-
-"@sk-web-gui/modal@2.2.6":
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/@sk-web-gui/modal/-/modal-2.2.6.tgz#c3ef558ad5b464883175918f590d346c9a89cd7c"
-  integrity sha512-lwIXDaBTLaSuHcgLkY2Sp4eiCycA/aTIT8QkC2DlP7PdSDVf38APpb1ELhcwuJ3ZivXdEcdIFOaJfMRdO6ttcA==
-  dependencies:
-    "@headlessui/react" "^2.2.0"
-    "@sk-web-gui/button" "2.1.6"
-    "@sk-web-gui/icon" "3.1.2"
-    "@sk-web-gui/utils" "2.2.2"
-    lucide-react "^0.471.1"
-
-"@sk-web-gui/popup-menu@3.1.6":
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/@sk-web-gui/popup-menu/-/popup-menu-3.1.6.tgz#61fe2a98ffd53353a67f88697160b696c415b0dd"
-  integrity sha512-8I8vYYzmX3BY2AyELsBIfvAGYYUR378kkVLJKIA3hrs7VAuZJLxTuWQtXS+xE8rh63P8ImXzwwbFHYm/IEEHZA==
-  dependencies:
-    "@sk-web-gui/button" "2.1.6"
-    "@sk-web-gui/link" "1.2.5"
-    "@sk-web-gui/theme" "2.5.1"
-    "@sk-web-gui/utils" "2.2.2"
-    usehooks-ts "^3.1.1"
-
-"@sk-web-gui/spinner@1.1.6":
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/@sk-web-gui/spinner/-/spinner-1.1.6.tgz#06894f9b81c998fe7533efe1d2d9e4875843cd0b"
-  integrity sha512-SNZ+TeO7+DvDXQysMgmd1k1ctyajpddcn7yXJp11FpzFp6N9+JApGTBXfILfTUrzLH37U8sGMeyI0rQZ2f+4/w==
-  dependencies:
-    "@sk-web-gui/theme" "2.5.1"
-    "@sk-web-gui/utils" "2.2.2"
-
-"@sk-web-gui/spinner@1.1.7":
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/@sk-web-gui/spinner/-/spinner-1.1.7.tgz#681154d0195f59930df585bc4fb98e1bc14f0736"
-  integrity sha512-jrS43RMF82jGSWF4GxAmhkjfqZcBNwDZqsGO8DTTFHYEsf4d8XBhxQMz2XMTDXowD4VYKxGDEnkA+GBhZS63iQ==
-  dependencies:
-    "@sk-web-gui/theme" "2.6.0"
-    "@sk-web-gui/utils" "2.2.2"
-
-"@sk-web-gui/theme@2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@sk-web-gui/theme/-/theme-2.5.1.tgz#40e49f0df1bcd683c5228737d21b41af74acbf38"
-  integrity sha512-VfvmWR0wVTiFEIB6BmdOQrgpC0l8IbhLRoac1sfDuVK/TB5mAt8OgXmfsMby+gRFAg0KchJkwWWvDnRXs9JN3Q==
-  dependencies:
-    "@sk-web-gui/utils" "2.2.2"
-    lodash.set "^4.3.2"
-    usehooks-ts "^3.1.1"
-
-"@sk-web-gui/theme@2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@sk-web-gui/theme/-/theme-2.6.0.tgz#11ca2eccb5256c7948b8fc2d1e3cfcb7efb5c8db"
-  integrity sha512-VJQKAiUjdulpcedox+gJCsO2IVSDs/QfJu2laJ+iUS/jycc/SSBFRgOhPSTVIsgyFiCZAvrjeaGo4goaVzBA/Q==
-  dependencies:
-    "@sk-web-gui/utils" "2.2.2"
-    lodash.set "^4.3.2"
-    usehooks-ts "^3.1.1"
-
 "@standard-schema/spec@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
@@ -3064,18 +2931,6 @@
   integrity sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==
   dependencies:
     "@types/node" "*"
-
-"@types/lodash.set@^4.3.9":
-  version "4.3.9"
-  resolved "https://registry.yarnpkg.com/@types/lodash.set/-/lodash.set-4.3.9.tgz#55d95bce407b42c6655f29b2d0811fd428e698f0"
-  integrity sha512-KOxyNkZpbaggVmqbpr82N2tDVTx05/3/j0f50Es1prxrWB0XYf9p3QNxqcbWb7P1Q9wlvsUSlCFnwlPCIJ46PQ==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*":
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.20.tgz#1ca77361d7363432d29f5e55950d9ec1e1c6ea93"
-  integrity sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==
 
 "@types/mdast@^4.0.0":
   version "4.0.4"
@@ -7542,11 +7397,6 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-  integrity sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==
-
 lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
@@ -7628,11 +7478,6 @@ lucide-react@0.544.0:
   version "0.544.0"
   resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.544.0.tgz#4719953c10fd53a64dd8343bb0ed16ec79f3eeef"
   integrity sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==
-
-lucide-react@^0.471.1:
-  version "0.471.2"
-  resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.471.2.tgz#817ead897ea630e982cb45e3429ee7f786dc3acb"
-  integrity sha512-A8fDycQxGeaSOTaI7Bm4fg8LBXO7Qr9ORAX47bDRvugCsjLIliugQO0PkKFoeAD57LIQwlWKd3NIQ3J7hYp84g==
 
 lucide-react@^0.553.0:
   version "0.553.0"
@@ -9939,7 +9784,7 @@ react-docgen@^8.0.0, react-docgen@^8.0.2:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
 
-react-hook-form@^7.54.2, react-hook-form@^7.62.0:
+react-hook-form@^7.62.0:
   version "7.62.0"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.62.0.tgz#2d81e13c2c6b6d636548e440818341ca753218d0"
   integrity sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==
@@ -11767,15 +11612,10 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-uuid@11.0.5:
-  version "11.0.5"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.0.5.tgz#07b46bdfa6310c92c3fb3953a8720f170427fc62"
-  integrity sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==
-
-uuid@11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
-  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
+uuid@11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 uuid@^10.0.0:
   version "10.0.0"


### PR DESCRIPTION
## What changed

- Removed the unused `lodash.set` dependency and its types from `@sk-web-gui/theme`.
- Updated `@sk-web-gui/forms` from `uuid@11.1.0` to `uuid@11.1.1`.
- Replaced the small hidden `lodash` usage in `@sk-web-gui/forms` with a local string-array comparison.
- Removed `lodash` from `@sk-web-gui/table`; `AutoTable` keeps the previous humanized header formatting (`'caseType'` -> `'Case type'`) via a small local helper that matches the old `upperFirst(lowerCase(...))` output, so rendered headers are unchanged for consumers.
- Removed the leftover phantom `lodash` import from the `forms` combobox story (dev-only; it only resolved via hoisting from `lerna`/`concurrently`).
- Updated `@sk-web-gui/countrycode-select` to consume the current `@sk-web-gui/forms` dependency so old published `forms -> theme -> lodash.set` entries fall out of the lockfile.
- Refreshed `yarn.lock` without adding resolutions or overrides.

## Why

Dependabot alerts in downstream apps were coming through transitive `@sk-web-gui/*` dependency chains. This fixes the upstream package owners instead of requiring consumers to add overrides.

## Validation

- `yarn install`
- `yarn build`
- `yarn workspace @sk-web-gui/forms build`
- `yarn lerna run build --scope @sk-web-gui/table --scope @sk-web-gui/react --stream`
- `yarn lerna run build --scope @sk-web-gui/theme --scope @sk-web-gui/forms --scope @sk-web-gui/table --scope @sk-web-gui/countrycode-select --stream`
- `yarn lerna run lint --scope @sk-web-gui/theme --scope @sk-web-gui/forms --scope @sk-web-gui/table --scope @sk-web-gui/countrycode-select --stream`
- `yarn lerna run lint --scope @sk-web-gui/table --stream`
- `yarn why lodash.set` returns no match
- `yarn why uuid` shows `@sk-web-gui/forms#uuid@11.1.1`
- `yarn why lodash` only reports dev-tool usage from `concurrently`/`lerna`, not `@sk-web-gui/table`
- The local header helper was compared against `lodash.upperFirst(lodash.lowerCase(...))` for 18 representative property names (camelCase, snake_case, kebab-case, digits, acronyms) with identical output, and `AutoTable` was SSR-rendered from source to confirm headers still come out as `Case type` / `Name` / `Id` / `Status` / `Created at`.

## Notes

`yarn lerna run test --scope ...` is currently blocked because the repo scripts call `jest`, but `jest` is not installed in the workspace.

`yarn install --frozen-lockfile` fails on `main` as well as this branch because `yarn.lock` has pre-existing mangled entries for `react@^19.1.1`/`react-dom@^19.1.1` (grouped into the `18.3.1` resolution). Left untouched here to keep the diff scoped; worth a separate fix.
